### PR TITLE
Remove interval from BaseDataModule

### DIFF
--- a/debugoverlay-no-op/src/main/java/com/ms_square/debugoverlay/modules/BaseDataModule.java
+++ b/debugoverlay-no-op/src/main/java/com/ms_square/debugoverlay/modules/BaseDataModule.java
@@ -5,10 +5,6 @@ import com.ms_square.debugoverlay.DataObserver;
 
 public abstract class BaseDataModule<T> implements DataModule<T> {
 
-    public BaseDataModule(int interval) {
-
-    }
-
     @Override
     public void notifyObservers() {
 
@@ -21,10 +17,6 @@ public abstract class BaseDataModule<T> implements DataModule<T> {
 
     @Override
     public void removeObserver(DataObserver observer) {
-    }
-
-    protected int getInterval() {
-        return 0;
     }
 
     protected abstract T getLatestData();

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/BaseDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/BaseDataModule.java
@@ -12,12 +12,6 @@ public abstract class BaseDataModule<T> implements DataModule<T> {
 
     private final List<DataObserver> observers = new ArrayList<>();
 
-    private final int interval;
-
-    public BaseDataModule(int interval) {
-        this.interval = interval;
-    }
-
     @Override
     public void notifyObservers() {
         T data = getLatestData();
@@ -36,10 +30,6 @@ public abstract class BaseDataModule<T> implements DataModule<T> {
     @Override
     public void removeObserver(@NonNull DataObserver observer) {
         observers.remove(observer);
-    }
-
-    protected int getInterval() {
-        return interval;
     }
 
     protected abstract T getLatestData();

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/CpuFreqDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/CpuFreqDataModule.java
@@ -122,8 +122,10 @@ class CpuFreqDataModule extends BaseDataModule<List<CpuFreq>> {
 
     private ScheduledExecutorService executorService;
 
+    private final int interval;
+
     public CpuFreqDataModule(int interval) {
-        super(interval);
+        this.interval = interval;
     }
 
     @Override
@@ -134,7 +136,7 @@ class CpuFreqDataModule extends BaseDataModule<List<CpuFreq>> {
         }
         if (executorService == null) {
             executorService = Executors.newSingleThreadScheduledExecutor();
-            executorService.scheduleWithFixedDelay(cpuFreqReadRunnable, 0, getInterval(), TimeUnit.MILLISECONDS);
+            executorService.scheduleWithFixedDelay(cpuFreqReadRunnable, 0, interval, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/CpuUsageDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/CpuUsageDataModule.java
@@ -22,8 +22,10 @@ class CpuUsageDataModule extends BaseDataModule<CpuUsage> {
 
     private ReaderThread cpuReaderThread;
 
+    private final int interval;
+
     public CpuUsageDataModule(int interval) {
-        super(interval);
+        this.interval = interval;
     }
 
     @Override
@@ -88,7 +90,7 @@ class CpuUsageDataModule extends BaseDataModule<CpuUsage> {
                 read();
                 closeCpuReaders();
                 try {
-                    Thread.currentThread().sleep(getInterval());
+                    Thread.currentThread().sleep(interval);
                 } catch (InterruptedException e) {
                     break;
                 }

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/FpsDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/FpsDataModule.java
@@ -13,8 +13,10 @@ class FpsDataModule extends BaseDataModule<Double> implements Choreographer.Fram
 
     private double fps;
 
+    private final int interval;
+
     public FpsDataModule(int interval) {
-        super(interval);
+        this.interval = interval;
         this.choreographer = Choreographer.getInstance();
     }
 
@@ -36,7 +38,7 @@ class FpsDataModule extends BaseDataModule<Double> implements Choreographer.Fram
             long duration = currentFrameTimeMillis - startFrameTimeMillis;
             numFramesRendered++;
 
-            if (duration > getInterval()) {
+            if (duration > interval) {
                 fps = numFramesRendered * 1000f / duration;
 
                 notifyObservers();

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/LogcatDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/LogcatDataModule.java
@@ -31,10 +31,6 @@ class LogcatDataModule extends BaseDataModule<LogcatLine> {
 
     private LogcatLine latestLine;
 
-    public LogcatDataModule() {
-        super(0);
-    }
-
     @Override
     public void start() {
         if (logcatReaderThread == null || !logcatReaderThread.isAlive()) {

--- a/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/MemInfoDataModule.java
+++ b/debugoverlay/src/main/java/com/ms_square/debugoverlay/modules/MemInfoDataModule.java
@@ -16,8 +16,10 @@ class MemInfoDataModule extends BaseDataModule<MemInfo> {
 
     private MemInfo memInfo;
 
+    private final int interval;
+
     public MemInfoDataModule(@NonNull Context context, int interval) {
-        super(interval);
+        this.interval = interval;
         am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
     }
 
@@ -44,7 +46,7 @@ class MemInfoDataModule extends BaseDataModule<MemInfo> {
             Debug.MemoryInfo processMemInfo = am.getProcessMemoryInfo(new int[]{Process.myPid()})[0];
             memInfo = new MemInfo(systemMemInfo, processMemInfo);
             notifyObservers();
-            handler.postDelayed(memInfoQueryRunnable, getInterval());
+            handler.postDelayed(memInfoQueryRunnable, interval);
         }
     };
 }

--- a/sample/src/main/java/com/ms_square/debugoverlay/sample/IPAddressDataModule.java
+++ b/sample/src/main/java/com/ms_square/debugoverlay/sample/IPAddressDataModule.java
@@ -26,8 +26,6 @@ public class IPAddressDataModule extends BaseDataModule<String> {
     private String ipAddresses;
 
     public IPAddressDataModule(@NonNull Context context) {
-        // pass 0 as interval since we don't use it anyway in this module
-        super(0);
         this.context = context;
     }
 


### PR DESCRIPTION
Hi Manabu-GT,

First of all I really like your library. I did however find it a bit odd that the `BaseDataModule` contained the 
refresh `interval` since not all `BaseDataModule`s need it, e.g., the `IPAddressDataModule`, and potentially other custom modules. This PR addresses this "issue". I'm putting issue in quotes since I don't know if you feel the same way.
Anyway I dont want to come off as ungrateful, the library is awesome, I just wanted to help make it even better.