### PR TITLE
Update Maven publishing configuration per module

### DIFF
--- a/debugoverlay-androidx-startup/gradle.properties
+++ b/debugoverlay-androidx-startup/gradle.properties
@@ -1,0 +1,4 @@
+# For maven central
+POM_ARTIFACT_ID=debugoverlay-androidx-startup
+POM_NAME=AndroidX StartUp config for DebugOverlay Android
+POM_PACKAGING=aar

--- a/debugoverlay-core/gradle.properties
+++ b/debugoverlay-core/gradle.properties
@@ -1,3 +1,4 @@
 # For maven central
-POM_ARTIFACT_ID=debugoverlay
-POM_NAME=DebugOverlay for Android
+POM_ARTIFACT_ID=debugoverlay-core
+POM_NAME=DebugOverlay Android - Core
+POM_PACKAGING=aar

--- a/debugoverlay/gradle.properties
+++ b/debugoverlay/gradle.properties
@@ -1,0 +1,4 @@
+# For maven central
+POM_ARTIFACT_ID=debugoverlay
+POM_NAME=DebugOverlay Android
+POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,11 +33,9 @@ RELEASE_SIGNING_ENABLED=true
 
 # For maven central
 GROUP=com.ms-square
-POM_ARTIFACT_ID=debugoverlay
 VERSION_NAME=1.1.4
 
 POM_URL=https://github.com/Manabu-GT/DebugOverlay-Android
-POM_NAME=DebugOverlay for Android
 POM_DESCRIPTION=Android library to display various debugging information in an overlay window
 
 POM_SCM_URL=https://github.com/Manabu-GT/DebugOverlay-Android


### PR DESCRIPTION
Refactors Maven Central publishing configuration by moving artifact metadata from root `gradle.properties` to per-module `gradle.properties` files.