### PR TITLE
[ui-tweak] remove the unnecessary debug panel title and close button

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelBottomSheet.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelBottomSheet.kt
@@ -3,17 +3,12 @@ package com.ms.square.debugoverlay.internal.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
@@ -25,7 +20,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -59,14 +53,12 @@ internal fun DebugPanelBottomSheet(onDismiss: () -> Unit) {
       )
     }
   ) {
-    DebugBottomSheetContent(
-      onDismiss = onDismiss
-    )
+    DebugBottomSheetContent()
   }
 }
 
 @Composable
-private fun DebugBottomSheetContent(modifier: Modifier = Modifier, onDismiss: () -> Unit = {}) {
+private fun DebugBottomSheetContent(modifier: Modifier = Modifier) {
   var selectedTabIndex by remember { mutableIntStateOf(0) }
   val tabs = remember { listOf(R.string.debugoverlay_tab_logcat, R.string.debugoverlay_tab_network) }
 
@@ -75,29 +67,6 @@ private fun DebugBottomSheetContent(modifier: Modifier = Modifier, onDismiss: ()
       .fillMaxWidth()
       .fillMaxHeight(BOTTOM_SHEET_HEIGHT_FRACTION)
   ) {
-    // Header with title and close button
-    Row(
-      modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 16.dp, vertical = 4.dp),
-      verticalAlignment = Alignment.CenterVertically
-    ) {
-      Text(
-        text = stringResource(R.string.debugoverlay_debug_panel),
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.weight(1f)
-      )
-      IconButton(
-        onClick = onDismiss
-      ) {
-        Icon(
-          imageVector = Icons.Default.Close,
-          contentDescription = stringResource(R.string.debugoverlay_close_description),
-          tint = MaterialTheme.colorScheme.onSurface
-        )
-      }
-    }
-
     // Tabs
     PrimaryTabRow(
       selectedTabIndex = selectedTabIndex,

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -13,8 +13,6 @@
   <string name="debugoverlay_netstat_unavailable">Network stats not available on this device</string>
   <string name="debugoverlay_tab_logcat">Logcat</string>
   <string name="debugoverlay_tab_network">Network</string>
-  <string name="debugoverlay_debug_panel">Debug Panel</string>
-  <string name="debugoverlay_close_description">Close</string>
   <string name="debugoverlay_back">Back</string>
   <string name="debugoverlay_message_label">MESSAGE</string>
   <string name="debugoverlay_copy">Copy</string>


### PR DESCRIPTION
- remove the unnecessary debug panel title and close button
-- gives more space to the actual content
-- bottom sheets use drag handles for dismissal. The explicit close button was redundant and reducing available space. 