### PR TITLE
[ui-tweaks] make typography consistent wrt Material 3

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Badges.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Badges.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ms.square.debugoverlay.internal.util.httpMethodColor
 import com.ms.square.debugoverlay.internal.util.httpStatusColor
 
@@ -30,8 +29,7 @@ internal fun MethodBadge(method: String, modifier: Modifier = Modifier) {
       modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
       style = MaterialTheme.typography.labelSmall,
       color = Color.Black,
-      fontWeight = FontWeight.Bold,
-      fontSize = 10.sp
+      fontWeight = FontWeight.Bold
     )
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DeviceInfoTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DeviceInfoTabContent.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.DeviceInfo
@@ -325,11 +324,10 @@ private fun InfoRow(label: String, value: String) {
     )
     Text(
       text = value,
-      style = MaterialTheme.typography.bodyMedium,
+      style = MaterialTheme.typography.bodySmall,
       color = MaterialTheme.colorScheme.onSurface,
       fontWeight = FontWeight.Medium,
       fontFamily = FontFamily.Monospace,
-      fontSize = 13.sp,
       textAlign = androidx.compose.ui.text.style.TextAlign.End,
       modifier = Modifier.weight(1f, fill = false)
     )
@@ -375,11 +373,10 @@ private fun BooleanInfoRow(label: String, value: Boolean, positiveIsGood: Boolea
         } else {
           stringResource(R.string.debugoverlay_device_info_no)
         },
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurface,
         fontWeight = FontWeight.Medium,
         fontFamily = FontFamily.Monospace,
-        fontSize = 13.sp,
         textAlign = androidx.compose.ui.text.style.TextAlign.End
       )
     }
@@ -407,11 +404,10 @@ private fun StorageIndicator(label: String, available: Long, total: Long) {
       )
       Text(
         text = formatBytes(available),
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurface,
         fontWeight = FontWeight.Medium,
-        fontFamily = FontFamily.Monospace,
-        fontSize = 13.sp
+        fontFamily = FontFamily.Monospace
       )
     }
 
@@ -437,8 +433,7 @@ private fun StorageIndicator(label: String, available: Long, total: Long) {
     Text(
       text = stringResource(R.string.debugoverlay_device_info_percentage_value, percentage),
       style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-      fontSize = 11.sp
+      color = MaterialTheme.colorScheme.onSurfaceVariant
     )
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/JankStatsTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/JankStatsTabContent.kt
@@ -234,9 +234,8 @@ private fun StateBreakdownCard(breakdown: List<StateJankCount>) {
               Spacer(Modifier.width(12.dp))
               Text(
                 text = item.state,
-                style = MaterialTheme.typography.bodyMedium,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace
               )
             }
             Text(

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogEntryDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogEntryDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.LogcatEntry
 import com.ms.square.debugoverlay.internal.data.model.toColor
@@ -144,11 +143,9 @@ private fun DetailMessageSection(message: String, modifier: Modifier = Modifier)
     ) {
       Text(
         text = message,
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodySmall,
         fontFamily = FontFamily.Monospace,
         color = MaterialTheme.colorScheme.onSurface,
-        fontSize = 13.sp,
-        lineHeight = 18.sp,
         modifier = Modifier.padding(12.dp)
       )
     }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogcatTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogcatTabContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,7 +40,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.LogLevel
@@ -176,7 +176,7 @@ private fun LogcatFilterBar(
   onLevelSelected: (LogLevel) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Column(modifier = modifier.fillMaxWidth()) {
+  Column(modifier = modifier.fillMaxWidth().padding(top = 8.dp)) {
     SearchField(
       searchPlaceholder = stringResource(R.string.debugoverlay_search_logs),
       searchQuery = searchQuery,
@@ -230,9 +230,8 @@ private fun LogcatContent(
     LazyColumn(
       state = listState,
       verticalArrangement = Arrangement.spacedBy(8.dp),
-      modifier = Modifier
-        .fillMaxSize()
-        .padding(horizontal = 16.dp)
+      modifier = Modifier.fillMaxSize(),
+      contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
     ) {
       items(filteredEntries, key = { it.id }) { entry ->
         LogcatEntryItem(
@@ -304,8 +303,6 @@ private fun LogcatEntryItem(entry: LogcatEntry, onClick: () -> Unit, modifier: M
         style = MaterialTheme.typography.bodySmall,
         fontFamily = FontFamily.Monospace,
         color = MaterialTheme.colorScheme.onSurface,
-        fontSize = 11.sp,
-        lineHeight = 14.sp,
         maxLines = 2,
         overflow = TextOverflow.Ellipsis
       )
@@ -323,28 +320,25 @@ private fun LogcatEntryMetadata(entry: LogcatEntry, modifier: Modifier = Modifie
     // Timestamp
     Text(
       text = entry.timestamp.takeLast(TIMESTAMP_DISPLAY_LENGTH),
-      style = MaterialTheme.typography.bodySmall,
+      style = MaterialTheme.typography.labelSmall,
       fontFamily = FontFamily.Monospace,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-      fontSize = 10.sp
+      color = MaterialTheme.colorScheme.onSurfaceVariant
     )
 
     // Bullet separator
     Text(
       text = "•",
-      style = MaterialTheme.typography.bodySmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-      fontSize = 10.sp
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
     )
 
     // Thread name
     Text(
       text = entry.threadName,
-      style = MaterialTheme.typography.bodySmall,
+      style = MaterialTheme.typography.labelSmall,
       fontFamily = FontFamily.Monospace,
       fontWeight = FontWeight.Bold,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
-      fontSize = 10.sp,
       maxLines = 1,
       overflow = TextOverflow.Ellipsis
     )
@@ -352,9 +346,8 @@ private fun LogcatEntryMetadata(entry: LogcatEntry, modifier: Modifier = Modifie
     // Bullet separator
     Text(
       text = "•",
-      style = MaterialTheme.typography.bodySmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-      fontSize = 10.sp
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
     )
 
     // Tag in colored chip
@@ -365,10 +358,9 @@ private fun LogcatEntryMetadata(entry: LogcatEntry, modifier: Modifier = Modifie
     ) {
       Text(
         text = entry.tag,
-        style = MaterialTheme.typography.bodySmall,
+        style = MaterialTheme.typography.labelSmall,
         fontFamily = FontFamily.Monospace,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 10.sp,
         modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/MetricRow.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/MetricRow.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 @Composable
 internal fun MetricRow(
@@ -43,10 +42,8 @@ internal fun MetricRow(
       )
       Text(
         text = label,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Medium,
-        letterSpacing = 0.1.sp
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
       )
     }
     LineGraph(
@@ -58,8 +55,8 @@ internal fun MetricRow(
     )
     Text(
       text = value,
+      style = MaterialTheme.typography.titleSmall,
       color = MaterialTheme.colorScheme.onSurface,
-      fontSize = 14.sp,
       fontWeight = FontWeight.SemiBold
     )
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.TextType
 import com.ms.square.debugoverlay.internal.data.UrlParts
@@ -423,8 +422,7 @@ private fun DetailSection(
           text = title,
           style = MaterialTheme.typography.labelLarge,
           color = MaterialTheme.colorScheme.primary,
-          fontWeight = FontWeight.Bold,
-          letterSpacing = 0.5.sp
+          fontWeight = FontWeight.Bold
         )
       }
 
@@ -486,16 +484,14 @@ private fun InfoRow(
     ) {
       Text(
         text = label,
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontSize = 13.sp
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
       )
 
       Text(
         text = value,
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodySmall,
         color = valueColor,
-        fontSize = 13.sp,
         fontWeight = FontWeight.Medium,
         fontFamily = FontFamily.Monospace,
         modifier = Modifier.padding(start = 16.dp)
@@ -547,8 +543,7 @@ private fun UrlDisplay(url: String, modifier: Modifier = Modifier) {
         text = parts.path,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.tertiary,
-        fontFamily = FontFamily.Monospace,
-        lineHeight = 18.sp
+        fontFamily = FontFamily.Monospace
       )
     }
   }
@@ -570,8 +565,7 @@ private fun HeaderItem(name: String, value: String, modifier: Modifier = Modifie
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.primary,
         fontWeight = FontWeight.Bold,
-        fontFamily = FontFamily.Monospace,
-        fontSize = 12.sp
+        fontFamily = FontFamily.Monospace
       )
 
       Text(
@@ -579,8 +573,6 @@ private fun HeaderItem(name: String, value: String, modifier: Modifier = Modifie
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurface,
         fontFamily = FontFamily.Monospace,
-        fontSize = 12.sp,
-        lineHeight = 18.sp,
         modifier = Modifier.padding(top = 4.dp)
       )
     }
@@ -644,11 +636,9 @@ private fun ErrorSection(error: com.ms.square.debugoverlay.model.NetworkError, m
           Text(
             text = error.stackTrace,
             modifier = Modifier.padding(12.dp),
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontFamily = FontFamily.Monospace,
-            fontSize = 11.sp,
-            lineHeight = 16.sp
+            fontFamily = FontFamily.Monospace
           )
         }
       }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.UrlParts
@@ -246,8 +246,7 @@ private fun NetworkStatsHeaderValue(
     Text(
       text = title,
       style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-      letterSpacing = 0.5.sp
+      color = MaterialTheme.colorScheme.onSurfaceVariant
     )
     Row(
       verticalAlignment = Alignment.CenterVertically,
@@ -305,7 +304,8 @@ private fun NetworkRequestItem(request: NetworkRequest, onClick: () -> Unit, mod
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             fontFamily = FontFamily.Monospace,
-            maxLines = 1
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
           )
         }
 
@@ -341,10 +341,9 @@ private fun NetworkRequestMetadata(
     // Domain
     Text(
       text = domain,
-      style = MaterialTheme.typography.bodySmall,
+      style = MaterialTheme.typography.labelSmall,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       fontFamily = FontFamily.Monospace,
-      fontSize = 11.sp,
       maxLines = 1
     )
 

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Texts.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Texts.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.ms.square.debugoverlay.internal.data.TextType
 import com.ms.square.debugoverlay.internal.util.copyToClipboard
@@ -115,9 +114,7 @@ internal fun CompactTextPreview(body: String, modifier: Modifier = Modifier) {
       modifier = Modifier.padding(16.dp),
       style = MaterialTheme.typography.bodySmall,
       color = MaterialTheme.colorScheme.onSurface,
-      fontFamily = FontFamily.Monospace,
-      fontSize = 12.sp,
-      lineHeight = 18.sp
+      fontFamily = FontFamily.Monospace
     )
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/UiTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/UiTabContent.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.util.copyToClipboard
 import kotlinx.coroutines.CancellationException
@@ -137,9 +136,8 @@ private fun HierarchyOutputDisplay(hierarchyOutput: String, modifier: Modifier =
           .verticalScroll(verticalScrollState)
           .horizontalScroll(horizontalScrollState)
           .padding(16.dp),
+        style = MaterialTheme.typography.labelSmall,
         fontFamily = FontFamily.Monospace,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
         color = MaterialTheme.colorScheme.onSurface
       )
     }


### PR DESCRIPTION
- make typography consistent wrt Material 3 + minor ui spacing tweaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined typography and spacing across debug overlay interface components for improved visual consistency.
  * Standardized text sizing throughout the UI using consistent design system scales.
  * Enhanced text overflow handling to properly display long text strings.
  * Improved spacing and padding consistency across various interface elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->