### PR TITLE
[ui-tweak] switch to PrimaryScrollableTabRow

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
@@ -12,8 +12,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -104,7 +104,7 @@ private fun DebugPanelContent(modifier: Modifier = Modifier) {
     modifier = modifier.fillMaxSize()
   ) {
     // Tabs
-    SecondaryScrollableTabRow(
+    PrimaryScrollableTabRow(
       selectedTabIndex = selectedTab.ordinal,
       modifier = Modifier.fillMaxWidth(),
       containerColor = Color.Transparent


### PR DESCRIPTION
- switch to PrimaryScrollableTabRow as it is the primary tabs shown on the full dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated debug panel tab styling for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->