### PR TITLE
[refactor] remove the auto dismiss from the draft bottom sheet

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftPickerScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftPickerScreen.kt
@@ -109,17 +109,6 @@ internal fun DraftPickerScreen(
   // Load thumbnails for drafts
   LoadThumbnailsEffect(bugReportGenerator, drafts, thumbnails)
 
-  // Dismiss sheet when all drafts are deleted
-  val visibleDrafts = state.draftSelectionState.filterVisible(drafts)
-  AutoDismissEffect(
-    bugReportGenerator = bugReportGenerator,
-    drafts = drafts,
-    visibleDrafts = visibleDrafts,
-    sheetState = state.sheetState,
-    draftSelectionState = state.draftSelectionState,
-    onDismiss = onDismiss
-  )
-
   // Create callbacks
   val callbacks = rememberDraftSelectionCallbacks(
     bugReportGenerator = bugReportGenerator,
@@ -173,33 +162,6 @@ private fun LoadThumbnailsEffect(
         }.getOrNull()
         thumbnails[draft.folderPath] = thumbnail
       }
-    }
-  }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AutoDismissEffect(
-  bugReportGenerator: BugReportGenerator,
-  drafts: List<DraftInfo>,
-  visibleDrafts: List<DraftInfo>,
-  sheetState: SheetState,
-  draftSelectionState: DraftSelectionState,
-  onDismiss: () -> Unit,
-) {
-  LaunchedEffect(visibleDrafts.size) {
-    if (drafts.isNotEmpty() && visibleDrafts.isEmpty()) {
-      // Delete pending drafts directly here (in suspend context with NonCancellable)
-      // This avoids launching a new coroutine that might not start if scope is cancelled
-      withContext(NonCancellable) {
-        // toList() to avoid ConcurrentModificationException when iterating and removing
-        draftSelectionState.pendingDelete.values.toList().forEach { draft ->
-          bugReportGenerator.deleteCaptureFolder(draft.folder)
-          draftSelectionState.confirmDelete(draft)
-        }
-      }
-      sheetState.hide()
-      onDismiss()
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic sheet dismissal behavior that occurred when all visible drafts were deleted. The sheet now requires explicit user action to dismiss, and pending drafts are no longer automatically removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->