### PR TITLE
bugfix: fix an overlay to save positions when re-parenting windows

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
@@ -328,7 +328,7 @@ internal class OverlayViewManager(
           currentLifecycleOwner?.onPause()
         }
         DebugOverlay.overlayDataRepository.pauseJankStatsTracking(activity)
-        // Save position on pause avoids excessive writes during drag
+        // Save position on pause to avoid excessive writes during active drag gestures
         savePosition()
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay persistence across window transitions: the overlay now preserves its on-screen position when switching target windows.
  * Position is also saved during active drag gestures, preventing unintended jumps when changing windows or lifecycle states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->