### PR TITLE
fix: display query parameters in network overlay UI

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/UrlParts.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/UrlParts.kt
@@ -2,14 +2,18 @@ package com.ms.square.debugoverlay.internal.data
 
 import androidx.core.net.toUri
 
-internal data class UrlParts(val scheme: String, val domain: String, val path: String) {
+internal data class UrlParts(val scheme: String, val domain: String, val path: String, val query: String?) {
+  val pathWithQuery: String
+    get() = if (query != null) "$path?$query" else path
+
   companion object {
     fun from(url: String): UrlParts {
       val uri = url.toUri()
       return UrlParts(
         scheme = uri.scheme ?: "",
         domain = uri.host ?: "",
-        path = uri.path ?: "/"
+        path = uri.path?.ifEmpty { "/" } ?: "/",
+        query = uri.query?.ifEmpty { null }
       )
     }
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -66,7 +66,7 @@ import com.ms.square.debugoverlay.model.NetworkRequest
 internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> Unit, modifier: Modifier = Modifier) {
   val clipboard = LocalClipboard.current
   val scope = rememberCoroutineScope()
-  val domain = remember(request.url) { UrlParts.from(request.url).domain }
+  val urlParts = remember(request.url) { UrlParts.from(request.url) }
 
   Scaffold(
     modifier = modifier.fillMaxSize(),
@@ -82,7 +82,7 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
               StatusCodeBadge(statusCode = request.statusCode)
             }
             Text(
-              text = domain,
+              text = urlParts.domain,
               style = MaterialTheme.typography.bodySmall,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
               maxLines = 1,
@@ -113,13 +113,14 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
   ) { paddingValues ->
     NetworkRequestDetailContent(
       request = request,
+      urlParts = urlParts,
       modifier = Modifier.padding(paddingValues)
     )
   }
 }
 
 @Composable
-private fun NetworkRequestDetailContent(request: NetworkRequest, modifier: Modifier = Modifier) {
+private fun NetworkRequestDetailContent(request: NetworkRequest, urlParts: UrlParts, modifier: Modifier = Modifier) {
   var selectedTab by remember { mutableIntStateOf(0) }
 
   Column(modifier = modifier.fillMaxSize()) {
@@ -148,7 +149,7 @@ private fun NetworkRequestDetailContent(request: NetworkRequest, modifier: Modif
     // Content
     SelectionContainer(modifier = Modifier.fillMaxSize()) {
       when (selectedTab) {
-        0 -> OverviewTab(request = request)
+        0 -> OverviewTab(request = request, urlParts = urlParts)
         1 -> HeadersTab(request = request)
         2 -> BodyTab(request = request)
       }
@@ -161,10 +162,9 @@ private fun NetworkRequestDetailContent(request: NetworkRequest, modifier: Modif
  */
 @Suppress("LongMethod") // Complex UI with multiple sections
 @Composable
-private fun OverviewTab(request: NetworkRequest, modifier: Modifier = Modifier) {
+private fun OverviewTab(request: NetworkRequest, urlParts: UrlParts, modifier: Modifier = Modifier) {
   val clipboard = LocalClipboard.current
   val scope = rememberCoroutineScope()
-  val urlParts = remember(request.url) { UrlParts.from(request.url) }
 
   LazyColumn(
     modifier = modifier.fillMaxSize(),

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -164,6 +164,7 @@ private fun NetworkRequestDetailContent(request: NetworkRequest, modifier: Modif
 private fun OverviewTab(request: NetworkRequest, modifier: Modifier = Modifier) {
   val clipboard = LocalClipboard.current
   val scope = rememberCoroutineScope()
+  val urlParts = remember(request.url) { UrlParts.from(request.url) }
 
   LazyColumn(
     modifier = modifier.fillMaxSize(),
@@ -185,7 +186,7 @@ private fun OverviewTab(request: NetworkRequest, modifier: Modifier = Modifier) 
           scope.copyToClipboard(clipboard, request.url)
         }
       ) {
-        UrlDisplay(url = request.url)
+        UrlDisplay(parts = urlParts)
       }
     }
 
@@ -510,14 +511,10 @@ private fun InfoRow(
 }
 
 /**
- * URL display with scheme, domain, and path.
+ * URL display with scheme, domain, path, and query parameters.
  */
 @Composable
-private fun UrlDisplay(url: String, modifier: Modifier = Modifier) {
-  val parts = remember(url) {
-    UrlParts.from(url)
-  }
-
+private fun UrlDisplay(parts: UrlParts, modifier: Modifier = Modifier) {
   Surface(
     modifier = modifier.fillMaxWidth(),
     shape = MaterialTheme.shapes.medium,
@@ -547,6 +544,16 @@ private fun UrlDisplay(url: String, modifier: Modifier = Modifier) {
         color = MaterialTheme.colorScheme.tertiary,
         fontFamily = FontFamily.Monospace
       )
+
+      if (parts.query != null) {
+        Text(
+          text = "?${parts.query}",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          fontFamily = FontFamily.Monospace,
+          modifier = Modifier.padding(top = 2.dp)
+        )
+      }
     }
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
@@ -299,7 +299,7 @@ private fun NetworkRequestItem(request: NetworkRequest, onClick: () -> Unit, mod
           MethodBadge(method = request.method)
 
           Text(
-            text = urlParts.path,
+            text = urlParts.pathWithQuery,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             fontFamily = FontFamily.Monospace,


### PR DESCRIPTION
## Summary

Fixes #222 — query parameters were not shown in the network overlay UI.

- **Root cause:** `UrlParts` used `uri.path` to parse the URL for display, which drops everything after `?`. Both the network list row and the detail screen's URL section relied on this, so query params were always invisible.
- **Data was never lost** — the full URL including query params was stored in `NetworkRequest.url`, copyable via the copy button, and searchable. This was a pure display bug.

## Changes

- `UrlParts`: add `query: String?` field, `pathWithQuery` computed property, and guard empty path/query edge cases
- `NetworkTabContent`: list row now shows `path?query` (truncated with ellipsis)
- `NetworkRequestDetailScreen`: query string displayed on its own line below path in the URL section; hoisted `UrlParts.from()` in `OverviewTab` to avoid double-parsing

## Test plan

- [x] Make a GET request with query parameters (e.g. `?page=1&limit=20`) and verify they appear in the network list row
- [x] Tap the request and verify the detail screen shows `?page=1&limit=20` below the path in the URL section
- [x] Verify requests with no query params display as before (no trailing `?`)
- [x] Verify the copy button still copies the full raw URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network request views now include query parameters so listed URLs show the full path+query.
* **Improvements**
  * Request detail view displays the query as a separate, clearly prefixed line for easier reading.
  * URL rendering in lists now includes query portions while preserving truncation and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->