### PR TITLE
docs: update README and changelog for v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* **Network tab** – Query parameters are now displayed in the URL section of the request detail screen (#222)
+* **Network tab** – Query parameters are now displayed in both the request list and the URL section of the request detail screen (#222)
 
 ## Version 2.2.0 *(2026-03-29)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 2.2.1 *(2026-04-13)*
+
+### Bug Fixes
+
+* **Network tab** – Query parameters are now displayed in the URL section of the request detail screen (#222)
+
 ## Version 2.2.0 *(2026-03-29)*
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.2.0")
+debugImplementation("com.ms-square:debugoverlay:2.2.1")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -71,7 +71,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.2.0"
+debugoverlay = "2.2.1"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -95,7 +95,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.2.0")
+  debugImplementation("com.ms-square:debugoverlay:2.2.1")
 }
 ```
 
@@ -143,8 +143,8 @@ DebugOverlay.configure {
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.2.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.2.0")
+  debugImplementation("com.ms-square:debugoverlay:2.2.1")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.2.1")
 }
 ```
 
@@ -175,8 +175,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.2.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.2.0")
+  debugImplementation("com.ms-square:debugoverlay:2.2.1")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.2.1")
 }
 ```
 
@@ -300,7 +300,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.2.0")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.2.1")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds v2.2.1 entry to `CHANGELOG.md` with the query params bug fix (#222)
- Bumps all version references in `README.md` from `2.2.0` → `2.2.1`

## Note

This PR should be merged after #223 (the actual fix) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query parameters now appear correctly in the request list and in the URL section of the request detail screen on the Network tab.

* **Documentation**
  * README Gradle dependency examples updated to reference DebugOverlay version 2.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->