### PR TITLE
feat: add hidden overlay mode and a new API to open panel programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Version 2.3.0 *(2026-04-30)
+
+### New Features
+
+* **Programmatic panel access** – New `OverlayMode.Hidden(customTabs)` suppresses the on-screen overlay entirely. New `DebugOverlay.openPanel(context)` launches the debug panel from any mode — wire it to your own debug menu, notification action, or gesture handler. Resolves [#228](https://github.com/Manabu-GT/DebugOverlay-Android/issues/228).
+
+### Source-compat notes
+
+* Adding `OverlayMode.Hidden` is source-breaking for downstream code that exhaustively `when`s on `OverlayMode`. Add a branch for `Hidden`.
+
 ## Version 2.2.1 *(2026-04-13)*
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Version 2.3.0 *(2026-04-30)
+## Version 2.3.0 *(2026-04-30)*
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ class MyApp : Application() {
 
 <img src="art/readme_bug_reporter_only.gif" alt="Bug Reporter Only Mode">
 
+### Headless mode (no on-screen overlay)
+
+Use `OverlayMode.Hidden` to suppress the on-screen overlay entirely and trigger the panel from your own UI — useful when QA testing is obscured by the overlay, or when you want to wire a debug menu, notification action, or shake gesture as the entry point.
+
+```kotlin
+DebugOverlay.configure {
+  overlayMode = OverlayMode.Hidden(
+    customTabs = listOf(/* optional custom tabs */)
+  )
+}
+
+// From your debug menu, notification action, etc.
+Button(onClick = { DebugOverlay.openPanel(context) }) {
+  Text("Open debug panel")
+}
+```
+
+`DebugOverlay.openPanel(context)` works in any mode, not just `Hidden` — call it from anywhere you'd like to launch the panel programmatically.
+
 ### Custom tabs
 
 Add app-specific tabs to the debug panel. Custom tabs appear after the built-in tabs:

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/DebugOverlay.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/DebugOverlay.kt
@@ -2,6 +2,8 @@ package com.ms.square.debugoverlay
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.content.Context
+import android.content.Intent
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
@@ -12,6 +14,7 @@ import com.ms.square.debugoverlay.internal.bugreport.BugReportGenerator
 import com.ms.square.debugoverlay.internal.bugreport.IntentShareExporter
 import com.ms.square.debugoverlay.internal.bugreport.validateFilename
 import com.ms.square.debugoverlay.internal.data.DebugOverlayDataRepository
+import com.ms.square.debugoverlay.internal.ui.DebugPanelActivity
 import com.ms.square.debugoverlay.internal.util.checkMainThread
 import com.ms.square.debugoverlay.internal.util.isMainProcess
 import kotlinx.coroutines.CoroutineScope
@@ -120,6 +123,24 @@ public object DebugOverlay {
   @AnyThread
   public fun configure(block: ConfigBuilder.() -> Unit) {
     config = ConfigBuilder(config).apply(block).build()
+  }
+
+  /**
+   * Launches the debug panel programmatically. Works in any [OverlayMode],
+   * including [OverlayMode.Hidden] where no overlay is shown.
+   *
+   * Typical usage from your debug menu:
+   * ```
+   * Button(onClick = { DebugOverlay.openPanel(context) }) { Text("Open debug panel") }
+   * ```
+   *
+   * @param context Any [Context].
+   */
+  @AnyThread
+  public fun openPanel(context: Context) {
+    val intent = Intent(context, DebugPanelActivity::class.java)
+      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(intent)
   }
 
   /**

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
@@ -13,7 +13,7 @@ package com.ms.square.debugoverlay
 public sealed interface OverlayMode {
 
   /**
-   * Modes that render the debug panel and accept custom tabs.
+   * Modes that support debug panel tabs and accept custom tabs.
    * Implemented by [FullMetrics] and [Hidden].
    */
   public sealed interface WithCustomTabs : OverlayMode {

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
@@ -11,6 +11,15 @@ package com.ms.square.debugoverlay
  * ```
  */
 public sealed interface OverlayMode {
+
+  /**
+   * Modes that render the debug panel and accept custom tabs.
+   * Implemented by [FullMetrics] and [Hidden].
+   */
+  public sealed interface WithCustomTabs : OverlayMode {
+    public val customTabs: List<DebugTab>
+  }
+
   /**
    * Shows real-time metrics panel (CPU, Memory, FPS).
    * Tapping opens the debug panel.
@@ -18,7 +27,7 @@ public sealed interface OverlayMode {
    *
    * @param customTabs Custom tabs appended after the built-in tabs in the debug panel.
    */
-  public data class FullMetrics(val customTabs: List<DebugTab> = emptyList()) : OverlayMode
+  public data class FullMetrics(override val customTabs: List<DebugTab> = emptyList()) : WithCustomTabs
 
   /**
    * Shows a minimal bug reporter FAB.
@@ -26,4 +35,14 @@ public sealed interface OverlayMode {
    * Best for QA/PM builds where real-time metrics panel isn't needed.
    */
   public data object BugReporterOnly : OverlayMode
+
+  /**
+   * No on-screen overlay. Use [DebugOverlay.openPanel] to open the panel programmatically.
+   *
+   * Use when the overlay would interfere with QA testing or when launching
+   * the panel from your own debug menu, notification action, or gesture handler.
+   *
+   * @param customTabs Custom tabs appended after the built-in tabs in the debug panel.
+   */
+  public data class Hidden(override val customTabs: List<DebugTab> = emptyList()) : WithCustomTabs
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
@@ -41,7 +41,13 @@ import curtains.Curtains
 import curtains.OnRootViewsChangedListener
 import curtains.phoneWindow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import java.lang.ref.WeakReference
 
 private const val OVERLAY_UPDATE_DEBOUNCE_MS = 100L
@@ -111,6 +117,15 @@ internal class OverlayViewManager(
     // Note: We don't remove this listener as OverlayViewManager is scoped to the application/singleton
     // and mimics the process lifecycle at the moment.
     Curtains.onRootViewsChangedListeners += rootsChangedListener
+
+    // React to runtime mode changes from configure { overlayMode = ... }.
+    // Without this, after a Hidden -> FullMetrics toggle, the overlay won't reappear
+    // until the next Curtains event (since hideOverlay() may have already destroyed
+    // the ComposeView that would have observed the StateFlow). drop(1) skips the
+    // initial value — initial attach is handled by the Curtains listener.
+    overlayMode.drop(1).distinctUntilChanged().onEach {
+      updateOverlayAttachment()
+    }.flowOn(Dispatchers.Main).launchIn(overlayScope)
   }
 
   private fun updateOverlayAttachment() {
@@ -241,10 +256,9 @@ internal class OverlayViewManager(
                 }
               )
             }
-            // Transient: after a runtime flip to Hidden, the existing window stays attached
-            // (rendering nothing) until the next updateOverlayAttachment call from the
-            // Curtains listener — which then early-returns and tears it down.
-            // Empty and non-focusable, so harmless until then.
+            // Transient state during the brief main-thread hop between overlayMode
+            // flipping to Hidden and updateOverlayAttachment() running to tear the
+            // window down.
             is OverlayMode.Hidden -> Unit
           }
         }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
@@ -3,7 +3,6 @@ package com.ms.square.debugoverlay.internal
 import android.app.Activity
 import android.app.Application
 import android.content.Context
-import android.content.Intent
 import android.graphics.PixelFormat
 import android.os.Build
 import android.os.Bundle
@@ -115,6 +114,12 @@ internal class OverlayViewManager(
   }
 
   private fun updateOverlayAttachment() {
+    // Hidden mode: tear down any existing window and skip attachment work
+    if (overlayMode.value is OverlayMode.Hidden) {
+      hideOverlay()
+      return
+    }
+
     // if no better target, just return
     val targetWindowView = findBestTargetWindow() ?: return
 
@@ -223,12 +228,7 @@ internal class OverlayViewManager(
                 initialOffsetX = overlayPreferences.getOverlayX().toFloat(),
                 initialOffsetY = overlayPreferences.getOverlayY().toFloat(),
                 onPositionChanged = onPositionChanged,
-                onClick = {
-                  val intent = Intent(application, DebugPanelActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                  }
-                  application.startActivity(intent)
-                }
+                onClick = { DebugOverlay.openPanel(application) }
               )
             }
             OverlayMode.BugReporterOnly -> {
@@ -241,6 +241,11 @@ internal class OverlayViewManager(
                 }
               )
             }
+            // Transient: after a runtime flip to Hidden, the existing window stays attached
+            // (rendering nothing) until the next updateOverlayAttachment call from the
+            // Curtains listener — which then early-returns and tears it down.
+            // Empty and non-focusable, so harmless until then.
+            is OverlayMode.Hidden -> Unit
           }
         }
       }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
@@ -237,7 +237,7 @@ private fun DebugPanelContent(modifier: Modifier = Modifier) {
   val repository = DebugOverlay.overlayDataRepository
   val hasCustomLogSource by repository.hasCustomLogSource.collectAsStateWithLifecycle()
   val customLogSourceName by repository.customLogSourceName.collectAsStateWithLifecycle()
-  val customTabs = (DebugOverlay.config.overlayMode as? OverlayMode.FullMetrics)?.customTabs.orEmpty()
+  val customTabs = (DebugOverlay.config.overlayMode as? OverlayMode.WithCustomTabs)?.customTabs.orEmpty()
 
   // Build visible tabs: built-in tabs (with CUSTOM_LOG conditionally shown) + custom tabs
   val visibleTabs = remember(hasCustomLogSource, customTabs) {

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/DebugOverlayTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/DebugOverlayTest.kt
@@ -1,8 +1,10 @@
 package com.ms.square.debugoverlay
 
 import android.content.Context
+import android.content.Intent
 import com.google.common.truth.Truth.assertThat
 import com.ms.square.debugoverlay.internal.bugreport.IntentShareExporter
+import com.ms.square.debugoverlay.internal.ui.DebugPanelActivity
 import com.ms.square.debugoverlay.model.BugReport
 import com.ms.square.debugoverlay.model.ExportResult
 import com.ms.square.debugoverlay.model.LogEntry
@@ -13,6 +15,8 @@ import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import java.io.OutputStream
 
 @RunWith(RobolectricTestRunner::class)
@@ -94,6 +98,31 @@ class DebugOverlayTest {
 
     val mode = DebugOverlay.config.overlayMode as OverlayMode.FullMetrics
     assertThat(mode.customTabs).containsExactly(tab1, tab2).inOrder()
+  }
+
+  @Test
+  fun `configure sets custom tabs on Hidden preserving order`() {
+    val tab1 = DebugTab(title = "Tab 1") {}
+    val tab2 = DebugTab(title = "Tab 2") {}
+
+    DebugOverlay.configure {
+      overlayMode = OverlayMode.Hidden(customTabs = listOf(tab1, tab2))
+    }
+
+    val mode = DebugOverlay.config.overlayMode as OverlayMode.Hidden
+    assertThat(mode.customTabs).containsExactly(tab1, tab2).inOrder()
+  }
+
+  @Test
+  fun `openPanel launches DebugPanelActivity with NEW_TASK flag`() {
+    val context = RuntimeEnvironment.getApplication()
+
+    DebugOverlay.openPanel(context)
+
+    val started = shadowOf(context).nextStartedActivity
+    assertThat(started.component?.className).isEqualTo(DebugPanelActivity::class.java.name)
+    assertThat(started.flags and Intent.FLAG_ACTIVITY_NEW_TASK)
+      .isEqualTo(Intent.FLAG_ACTIVITY_NEW_TASK)
   }
 
   @Test

--- a/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
+++ b/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
@@ -13,13 +13,16 @@ object DebugOverlaySetup {
   fun init(context: Context) {
     val appContext = context.applicationContext
 
-    // Add a custom tab showing SharedPreferences
+    val customTabs = listOf(
+      DebugTab(title = "SharedPrefs") { SharedPrefsTabContent(appContext) }
+    )
+
+    // Add a custom tab showing SharedPreferences.
+    // Swap to OverlayMode.Hidden(customTabs) to hide the on-screen overlay entirely
+    // and trigger the panel via DebugOverlay.openPanel(context) — see "Open Debug Panel"
+    // card on the Overlay Tests screen.
     DebugOverlay.configure {
-      overlayMode = OverlayMode.FullMetrics(
-        customTabs = listOf(
-          DebugTab(title = "SharedPrefs") { SharedPrefsTabContent(appContext) }
-        )
-      )
+      overlayMode = OverlayMode.FullMetrics(customTabs = customTabs)
     }
 
     // Also contribute the same data to bug reports

--- a/sample/src/main/kotlin/com/ms/square/debugoverlay/sample/ui/overlaytests/OverlayTestsScreen.kt
+++ b/sample/src/main/kotlin/com/ms/square/debugoverlay/sample/ui/overlaytests/OverlayTestsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.VerticalAlignBottom
 import androidx.compose.material.icons.filled.ViewAgenda
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -25,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -37,6 +38,8 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.FragmentActivity
+import com.ms.square.debugoverlay.DebugOverlay
+import com.ms.square.debugoverlay.OverlayMode
 import com.ms.square.debugoverlay.sample.SecondActivity
 
 /**
@@ -55,6 +58,7 @@ internal fun OverlayTestsScreen(modifier: Modifier = Modifier) {
   var showComposeDialog by rememberSaveable { mutableStateOf(false) }
   var showComposeBottomSheet by rememberSaveable { mutableStateOf(false) }
   var isFullscreen by rememberSaveable { mutableStateOf(false) }
+  var isOverlayHidden by rememberSaveable { mutableStateOf(false) }
 
   // Reset fullscreen mode when leaving the screen
   DisposableEffect(Unit) {
@@ -183,6 +187,43 @@ internal fun OverlayTestsScreen(modifier: Modifier = Modifier) {
               setFullscreenMode(it, isFullscreen)
             }
           },
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+
+      // Section: Programmatic API
+      item {
+        SectionHeader("Programmatic API")
+      }
+
+      item {
+        // Sample-only toggle: configures with empty customTabs, so the SharedPrefs tab
+        // disappears for the rest of the session. Production code should re-pass its tabs.
+        TestScenarioCard(
+          title = if (isOverlayHidden) "Show Overlay" else "Hide Overlay",
+          description = if (isOverlayHidden) {
+            "Switch back to FullMetrics — overlay reappears"
+          } else {
+            "Switch to OverlayMode.Hidden — overlay disappears, panel still works via openPanel"
+          },
+          icon = if (isOverlayHidden) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+          onClick = {
+            val nextHidden = !isOverlayHidden
+            DebugOverlay.configure {
+              overlayMode = if (nextHidden) OverlayMode.Hidden() else OverlayMode.FullMetrics()
+            }
+            isOverlayHidden = nextHidden
+          },
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+
+      item {
+        TestScenarioCard(
+          title = "Open Debug Panel",
+          description = "Launch the panel via DebugOverlay.openPanel() — works in any OverlayMode, including Hidden",
+          icon = Icons.AutoMirrored.Filled.OpenInNew,
+          onClick = { DebugOverlay.openPanel(context) },
           modifier = Modifier.fillMaxWidth()
         )
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `OverlayMode.Hidden` to suppress the on-screen overlay while enabling programmatic debug panel access.
  * Added `DebugOverlay.openPanel()` API to trigger the debug panel from external UI across all overlay modes.

* **Documentation**
  * Updated changelog and README with headless configuration examples and usage guidance.

* **Tests**
  * Added test coverage for hidden mode and programmatic panel functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->