### PR TITLE
docs: update README for v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.4.0")
+debugImplementation("com.ms-square:debugoverlay:2.5.0")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -72,7 +72,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.4.0"
+debugoverlay = "2.5.0"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -98,7 +98,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.4.0")
+  debugImplementation("com.ms-square:debugoverlay:2.5.0")
 }
 ```
 
@@ -153,8 +153,8 @@ For a zero-config shake trigger, add the shake extension:
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.4.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.4.0")
+  debugImplementation("com.ms-square:debugoverlay:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.5.0")
 }
 ```
 
@@ -182,8 +182,8 @@ DebugOverlay.configure {
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.4.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.4.0")
+  debugImplementation("com.ms-square:debugoverlay:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.5.0")
 }
 ```
 
@@ -214,8 +214,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.4.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.4.0")
+  debugImplementation("com.ms-square:debugoverlay:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.5.0")
 }
 ```
 
@@ -339,7 +339,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.4.0")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.5.0")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Bumped install snippets from `2.4.0` to `2.5.0` across Quick Start, Version Catalog, Kotlin DSL, the OkHttp / Timber / shake-trigger extensions, and the `releaseWithOverlay` example.
- The Clear Logs feature description already landed in the README via #242, and the v2.5.0 `CHANGELOG.md` entry is in place — this PR is just the version bump.

## Test plan
- [x] Verify rendered README on GitHub shows `2.5.0` in every code snippet
- [x] Confirm no stale `2.4.0` references remain (`grep -n "2\.4\.0" README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all Gradle dependency examples and version references across Quick Start snippets, version catalogs, Kotlin DSL configurations, and extension dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Manabu-GT/DebugOverlay-Android/pull/243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->