### PR TITLE
[feat] add a thermal status row to the debug overlay panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* **Thermal status row** – Optional thermal-status indicator for the compact overlay, opt-in via `OverlayMode.FullMetrics(showThermal = true)`. Combines `PowerManager.getCurrentThermalStatus()` with `getThermalHeadroom()` per [Google's ADPF guidance](https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api) so devices with an incomplete thermal HAL still surface a useful signal. Requires Android 11 (API 30) or above; row stays hidden on unsupported devices. Resolves [#246](https://github.com/Manabu-GT/DebugOverlay-Android/issues/246).
+* **Thermal status row** – Optional thermal-status indicator for the compact overlay, opt-in via `OverlayMode.FullMetrics(showThermal = true)`. Combines `PowerManager.getCurrentThermalStatus()` with `getThermalHeadroom()` per [Google's ADPF guidance](https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api) so devices with an incomplete thermal HAL still surface a useful signal. Requires Android 11 (API 30) or above; row stays hidden on older devices. Resolves [#246](https://github.com/Manabu-GT/DebugOverlay-Android/issues/246).
 
 ## Version 2.5.0 *(2026-05-12)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 2.6.0 *(2026-05-18)*
+
+### New Features
+
+* **Thermal status row** – Optional thermal-status indicator for the compact overlay, opt-in via `OverlayMode.FullMetrics(showThermal = true)`. Combines `PowerManager.getCurrentThermalStatus()` with `getThermalHeadroom()` per [Google's ADPF guidance](https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api) so devices with an incomplete thermal HAL still surface a useful signal. Requires Android 11 (API 30) or above; row stays hidden on unsupported devices. Resolves [#246](https://github.com/Manabu-GT/DebugOverlay-Android/issues/246).
+
 ## Version 2.5.0 *(2026-05-12)*
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ DebugOverlay.configure {
 }
 ```
 
-The row shows the current thermal-throttling level with a color-coded dot. Labels are abbreviated to fit the compact panel — `None` / `Light` / `Mod` / `Sev` / `Crit` / `Emer` / `Shut` — mapping to `PowerManager.THERMAL_STATUS_NONE` / `_LIGHT` / `_MODERATE` / `_SEVERE` / `_CRITICAL` / `_EMERGENCY` / `_SHUTDOWN` respectively. Requires Android 11 (API 30) or above; the row stays hidden on older devices or on devices whose thermal HAL is not implemented.
+The row shows the current thermal-throttling level with a color-coded dot. Labels are abbreviated to fit the compact panel — `None` / `Light` / `Mod` / `Sev` / `Crit` / `Emer` / `Shut` — mapping to `PowerManager.THERMAL_STATUS_NONE` / `_LIGHT` / `_MODERATE` / `_SEVERE` / `_CRITICAL` / `_EMERGENCY` / `_SHUTDOWN` respectively. Requires Android 11 (API 30) or above with a working thermal HAL — the row stays hidden on older devices and on API 30+ devices whose HAL doesn't expose `getThermalHeadroom` data. If the HAL later starts reporting, the row appears on the next poll.
 
 ### Network request tracking
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Draggable overlay with real-time metrics and sparklines:
 - **Heap** – JVM heap usage percentage
 - **PSS** – Proportional Set Size in MB
 - **FPS** – Real-time frame rate
+- **Thermal** – *(optional, Android 11+)* Device thermal status — enable via `OverlayMode.FullMetrics(showThermal = true)`
 
 ### Debug Panel
 Tap the overlay to open a full-screen diagnostic panel:
@@ -177,6 +178,18 @@ DebugOverlay.configure {
   )
 }
 ```
+
+### Thermal status
+
+Opt in to a thermal-status row in the compact overlay:
+
+```kotlin
+DebugOverlay.configure {
+  overlayMode = OverlayMode.FullMetrics(showThermal = true)
+}
+```
+
+The row shows the current `PowerManager.THERMAL_STATUS_*` level (`NONE`/`LIGHT`/`MOD`/`SEV`/`CRIT`/`EMER`/`SHUT`) with a color-coded dot. Requires Android 11 (API 30) or above; the row stays hidden on older devices or on devices whose thermal HAL is not implemented.
 
 ### Network request tracking
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ DebugOverlay.configure {
 }
 ```
 
-The row shows the current `PowerManager.THERMAL_STATUS_*` level (`NONE`/`LIGHT`/`MOD`/`SEV`/`CRIT`/`EMER`/`SHUT`) with a color-coded dot. Requires Android 11 (API 30) or above; the row stays hidden on older devices or on devices whose thermal HAL is not implemented.
+The row shows the current thermal-throttling level with a color-coded dot. Labels are abbreviated to fit the compact panel — `None` / `Light` / `Mod` / `Sev` / `Crit` / `Emer` / `Shut` — mapping to `PowerManager.THERMAL_STATUS_NONE` / `_LIGHT` / `_MODERATE` / `_SEVERE` / `_CRITICAL` / `_EMERGENCY` / `_SHUTDOWN` respectively. Requires Android 11 (API 30) or above; the row stays hidden on older devices or on devices whose thermal HAL is not implemented.
 
 ### Network request tracking
 

--- a/debugoverlay-core/src/debug/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanelPreviews.kt
+++ b/debugoverlay-core/src/debug/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanelPreviews.kt
@@ -37,8 +37,7 @@ private fun DebugOverlayPanelPreview(
   heapPercent: Float = 72f,
   pss: Float = 256f,
   fps: Float = 60f,
-  thermalStatus: ThermalStatus = ThermalStatus.UNSUPPORTED,
-  showThermal: Boolean = false,
+  thermalState: ThermalState? = null,
 ) {
   // Mock data that updates for preview
   var metrics by remember {
@@ -50,8 +49,7 @@ private fun DebugOverlayPanelPreview(
         fpsMetrics = Metrics(fps, listOf(60f, 59f, 60f, 60f, 58f, 60f, 59f, fps)),
         targetFps = 90f,
         maxFps = 90f,
-        maxPss = 512f, // Typical mid-range device
-        thermalState = ThermalState(thermalStatus)
+        maxPss = 512f // Typical mid-range device
       )
     )
   }
@@ -88,8 +86,8 @@ private fun DebugOverlayPanelPreview(
 
   DebugOverlayPanel(
     metrics = metrics,
-    showThermal = showThermal,
-    modifier = modifier
+    modifier = modifier,
+    thermalState = thermalState
   )
 }
 
@@ -234,8 +232,7 @@ private fun DebugOverlayPreviewWithThermal() {
         heapPercent = 65f,
         pss = 380f,
         fps = 42f,
-        thermalStatus = ThermalStatus.SEVERE,
-        showThermal = true
+        thermalState = ThermalState(ThermalStatus.SEVERE)
       )
     }
   }

--- a/debugoverlay-core/src/debug/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanelPreviews.kt
+++ b/debugoverlay-core/src/debug/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanelPreviews.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ms.square.debugoverlay.internal.data.model.DebugOverlayPanelMetrics
 import com.ms.square.debugoverlay.internal.data.model.Metrics
+import com.ms.square.debugoverlay.internal.data.model.ThermalState
+import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
 import kotlinx.coroutines.delay
 
 // Composable Previews with static data (no performance monitoring)
@@ -35,6 +37,8 @@ private fun DebugOverlayPanelPreview(
   heapPercent: Float = 72f,
   pss: Float = 256f,
   fps: Float = 60f,
+  thermalStatus: ThermalStatus = ThermalStatus.UNSUPPORTED,
+  showThermal: Boolean = false,
 ) {
   // Mock data that updates for preview
   var metrics by remember {
@@ -46,7 +50,8 @@ private fun DebugOverlayPanelPreview(
         fpsMetrics = Metrics(fps, listOf(60f, 59f, 60f, 60f, 58f, 60f, 59f, fps)),
         targetFps = 90f,
         maxFps = 90f,
-        maxPss = 512f // Typical mid-range device
+        maxPss = 512f, // Typical mid-range device
+        thermalState = ThermalState(thermalStatus)
       )
     )
   }
@@ -83,6 +88,7 @@ private fun DebugOverlayPanelPreview(
 
   DebugOverlayPanel(
     metrics = metrics,
+    showThermal = showThermal,
     modifier = modifier
   )
 }
@@ -207,6 +213,29 @@ private fun DebugOverlayPreviewHighLoad() {
         heapPercent = 92f,
         pss = 800f,
         fps = 25f
+      )
+    }
+  }
+}
+
+@Preview(name = "Panel Only - With Thermal (Severe)", showBackground = true, widthDp = 200, heightDp = 200)
+@Composable
+private fun DebugOverlayPreviewWithThermal() {
+  MaterialTheme {
+    Box(
+      modifier = Modifier
+        .fillMaxSize()
+        .background(MaterialTheme.colorScheme.background)
+        .padding(16.dp),
+      contentAlignment = Alignment.Center
+    ) {
+      DebugOverlayPanelPreview(
+        cpuPercent = 72f,
+        heapPercent = 65f,
+        pss = 380f,
+        fps = 42f,
+        thermalStatus = ThermalStatus.SEVERE,
+        showThermal = true
       )
     }
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
@@ -27,8 +27,10 @@ public sealed interface OverlayMode {
    *
    * @param customTabs Custom tabs appended after the built-in tabs in the debug panel.
    * @param showThermal When `true`, adds a thermal-status row to the real-time metrics panel.
-   *   Requires Android 11 (API 30) or above. On older or thermal-HAL-incomplete devices the
-   *   row stays hidden even when this flag is set. Defaults to `false`.
+   *   Requires Android 11 (API 30) or above with a working thermal HAL — the row stays hidden
+   *   on older devices and on API 30+ devices whose HAL does not expose `getThermalHeadroom`
+   *   data. If a HAL later starts reporting real values, the row appears on the next poll.
+   *   Defaults to `false`.
    */
   public data class FullMetrics(
     override val customTabs: List<DebugTab> = emptyList(),

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/OverlayMode.kt
@@ -26,8 +26,14 @@ public sealed interface OverlayMode {
    * Best for developers during active development/testing.
    *
    * @param customTabs Custom tabs appended after the built-in tabs in the debug panel.
+   * @param showThermal When `true`, adds a thermal-status row to the real-time metrics panel.
+   *   Requires Android 11 (API 30) or above. On older or thermal-HAL-incomplete devices the
+   *   row stays hidden even when this flag is set. Defaults to `false`.
    */
-  public data class FullMetrics(override val customTabs: List<DebugTab> = emptyList()) : WithCustomTabs
+  public data class FullMetrics(
+    override val customTabs: List<DebugTab> = emptyList(),
+    public val showThermal: Boolean = false,
+  ) : WithCustomTabs
 
   /**
    * Shows a minimal bug reporter FAB.

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
@@ -233,13 +233,14 @@ internal class OverlayViewManager(
           }
         ) {
           val currentOverlayMode by overlayMode.collectAsStateWithLifecycle()
-          when (currentOverlayMode) {
+          when (val mode = currentOverlayMode) {
             is OverlayMode.FullMetrics -> {
               val metrics by debugPanelDataSource.debugOverlayPanelMetrics.collectAsStateWithLifecycle(
                 initialValue = null
               )
               DraggableOverlayPanel(
                 metrics = metrics,
+                showThermal = mode.showThermal,
                 initialOffsetX = overlayPreferences.getOverlayX().toFloat(),
                 initialOffsetY = overlayPreferences.getOverlayY().toFloat(),
                 onPositionChanged = onPositionChanged,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/OverlayViewManager.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -30,6 +31,7 @@ import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.bugreport.ActivityProvider
 import com.ms.square.debugoverlay.internal.bugreport.ui.BugReportActivity
 import com.ms.square.debugoverlay.internal.bugreport.ui.DraggableBugReporterFab
+import com.ms.square.debugoverlay.internal.data.model.ThermalState
 import com.ms.square.debugoverlay.internal.data.source.DebugOverlayPanelDataSourceImpl
 import com.ms.square.debugoverlay.internal.data.source.OverlayPreferences
 import com.ms.square.debugoverlay.internal.data.source.SharedPreferencesOverlayPreferences
@@ -42,9 +44,11 @@ import curtains.OnRootViewsChangedListener
 import curtains.phoneWindow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -238,9 +242,13 @@ internal class OverlayViewManager(
               val metrics by debugPanelDataSource.debugOverlayPanelMetrics.collectAsStateWithLifecycle(
                 initialValue = null
               )
+              val thermalFlow: Flow<ThermalState?> = remember(mode.showThermal) {
+                if (mode.showThermal) debugPanelDataSource.thermalState else flowOf(null)
+              }
+              val thermalState by thermalFlow.collectAsStateWithLifecycle(initialValue = null)
               DraggableOverlayPanel(
                 metrics = metrics,
-                showThermal = mode.showThermal,
+                thermalState = thermalState,
                 initialOffsetX = overlayPreferences.getOverlayX().toFloat(),
                 initialOffsetY = overlayPreferences.getOverlayY().toFloat(),
                 onPositionChanged = onPositionChanged,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/DebugOverlayPanelMetrics.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/DebugOverlayPanelMetrics.kt
@@ -8,5 +8,4 @@ internal data class DebugOverlayPanelMetrics(
   val fpsMetrics: Metrics,
   val targetFps: Float,
   val maxFps: Float,
-  val thermalState: ThermalState,
 )

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/DebugOverlayPanelMetrics.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/DebugOverlayPanelMetrics.kt
@@ -8,4 +8,5 @@ internal data class DebugOverlayPanelMetrics(
   val fpsMetrics: Metrics,
   val targetFps: Float,
   val maxFps: Float,
+  val thermalState: ThermalState,
 )

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
@@ -1,7 +1,5 @@
 package com.ms.square.debugoverlay.internal.data.model
 
-import kotlinx.serialization.Serializable
-
 /**
  * Current thermal throttling state of the device.
  *
@@ -10,7 +8,6 @@ import kotlinx.serialization.Serializable
  * the Android ADPF documentation:
  * https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api
  */
-@Serializable
 internal data class ThermalState(val status: ThermalStatus)
 
 /**
@@ -20,7 +17,6 @@ internal data class ThermalState(val status: ThermalStatus)
  *
  * Levels mirror the `PowerManager.THERMAL_STATUS_*` constants.
  */
-@Serializable
 internal enum class ThermalStatus {
   NONE,
   LIGHT,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
@@ -11,11 +11,13 @@ package com.ms.square.debugoverlay.internal.data.model
 internal data class ThermalState(val status: ThermalStatus)
 
 /**
- * Thermal throttling level reported by the platform, or [UNSUPPORTED] when the device
- * does not support the thermal headroom API (API < 30, or API 30+ device with an
- * incomplete thermal HAL implementation).
- *
- * Levels mirror the `PowerManager.THERMAL_STATUS_*` constants.
+ * Thermal throttling level reported by the platform. Levels [NONE] through [SHUTDOWN] mirror
+ * the `PowerManager.THERMAL_STATUS_*` constants. [UNSUPPORTED] is a synthetic value emitted
+ * when the device cannot report thermal data — either because it pre-dates the thermal API
+ * (Android < 11 / API < 30) or because the thermal HAL is incomplete and
+ * `getThermalHeadroom()` returns `NaN` per its Javadoc contract. The UI hides the row in
+ * both cases. If a HAL later begins returning real headroom values, the state self-heals
+ * to a real level on the next poll.
  */
 internal enum class ThermalStatus {
   NONE,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/model/ThermalState.kt
@@ -1,0 +1,33 @@
+package com.ms.square.debugoverlay.internal.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Current thermal throttling state of the device.
+ *
+ * Derived from a combination of [android.os.PowerManager.getCurrentThermalStatus] and
+ * [android.os.PowerManager.getThermalHeadroom] (API 30+) using the heuristic described in
+ * the Android ADPF documentation:
+ * https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api
+ */
+@Serializable
+internal data class ThermalState(val status: ThermalStatus)
+
+/**
+ * Thermal throttling level reported by the platform, or [UNSUPPORTED] when the device
+ * does not support the thermal headroom API (API < 30, or API 30+ device with an
+ * incomplete thermal HAL implementation).
+ *
+ * Levels mirror the `PowerManager.THERMAL_STATUS_*` constants.
+ */
+@Serializable
+internal enum class ThermalStatus {
+  NONE,
+  LIGHT,
+  MODERATE,
+  SEVERE,
+  CRITICAL,
+  EMERGENCY,
+  SHUTDOWN,
+  UNSUPPORTED,
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/DebugOverlayPanelDataSource.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/DebugOverlayPanelDataSource.kt
@@ -20,6 +20,7 @@ internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: C
   private val cpuDataSource = CpuDataSource()
   private val memoryDataSource = MemoryDataSource(context)
   private val fpsDataSource = FpsDataSource(context)
+  private val thermalDataSource = ThermalDataSource(context)
 
   // Accumulators for maintaining history across flow collection restarts
   private val cpuAccumulator = MetricsAccumulator()
@@ -31,8 +32,9 @@ internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: C
     cpuDataSource.cpuUsage().map { cpuAccumulator.accumulate(it.value) },
     memoryDataSource.heapUsage().map { heapAccumulator.accumulate(it.value) },
     memoryDataSource.pss().map { pssAccumulator.accumulate(it) },
-    fpsDataSource.fps().map { fpsAccumulator.accumulate(it) }
-  ) { cpuMetrics, heapMetrics, pssMetrics, fpsMetrics ->
+    fpsDataSource.fps().map { fpsAccumulator.accumulate(it) },
+    thermalDataSource.thermalState()
+  ) { cpuMetrics, heapMetrics, pssMetrics, fpsMetrics, thermalState ->
     DebugOverlayPanelMetrics(
       cpuMetrics = cpuMetrics,
       heapMetrics = heapMetrics,
@@ -40,7 +42,8 @@ internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: C
       maxPss = memoryDataSource.maxPss,
       fpsMetrics = fpsMetrics,
       targetFps = fpsDataSource.currentTargetFps,
-      maxFps = fpsDataSource.maxSupportedFps
+      maxFps = fpsDataSource.maxSupportedFps,
+      thermalState = thermalState
     )
   }
     .shareIn(

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/DebugOverlayPanelDataSource.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/DebugOverlayPanelDataSource.kt
@@ -3,6 +3,7 @@ package com.ms.square.debugoverlay.internal.data.source
 import android.content.Context
 import com.ms.square.debugoverlay.internal.data.model.DebugOverlayPanelMetrics
 import com.ms.square.debugoverlay.internal.data.model.MetricsAccumulator
+import com.ms.square.debugoverlay.internal.data.model.ThermalState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,6 +13,14 @@ import kotlinx.coroutines.flow.shareIn
 
 internal sealed interface DebugOverlayPanelDataSource {
   val debugOverlayPanelMetrics: Flow<DebugOverlayPanelMetrics?>
+
+  /**
+   * Thermal status flow, exposed separately from [debugOverlayPanelMetrics] so consumers can
+   * subscribe conditionally (e.g. only when `OverlayMode.FullMetrics.showThermal` is `true`).
+   * Backed by `shareIn(WhileSubscribed)` so the underlying PowerManager listener / headroom
+   * polling only runs while something is collecting.
+   */
+  val thermalState: Flow<ThermalState>
 }
 
 internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: CoroutineScope) :
@@ -28,13 +37,12 @@ internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: C
   private val pssAccumulator = MetricsAccumulator()
   private val fpsAccumulator = MetricsAccumulator()
 
-  private val sharedMetrics: Flow<DebugOverlayPanelMetrics?> = combine(
+  override val debugOverlayPanelMetrics: Flow<DebugOverlayPanelMetrics?> = combine(
     cpuDataSource.cpuUsage().map { cpuAccumulator.accumulate(it.value) },
     memoryDataSource.heapUsage().map { heapAccumulator.accumulate(it.value) },
     memoryDataSource.pss().map { pssAccumulator.accumulate(it) },
-    fpsDataSource.fps().map { fpsAccumulator.accumulate(it) },
-    thermalDataSource.thermalState()
-  ) { cpuMetrics, heapMetrics, pssMetrics, fpsMetrics, thermalState ->
+    fpsDataSource.fps().map { fpsAccumulator.accumulate(it) }
+  ) { cpuMetrics, heapMetrics, pssMetrics, fpsMetrics ->
     DebugOverlayPanelMetrics(
       cpuMetrics = cpuMetrics,
       heapMetrics = heapMetrics,
@@ -42,16 +50,10 @@ internal class DebugOverlayPanelDataSourceImpl(context: Context, overlayScope: C
       maxPss = memoryDataSource.maxPss,
       fpsMetrics = fpsMetrics,
       targetFps = fpsDataSource.currentTargetFps,
-      maxFps = fpsDataSource.maxSupportedFps,
-      thermalState = thermalState
+      maxFps = fpsDataSource.maxSupportedFps
     )
-  }
-    .shareIn(
-      scope = overlayScope,
-      started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 1_000),
-      replay = 1
-    )
+  }.shareIn(overlayScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 1_000), replay = 1)
 
-  override val debugOverlayPanelMetrics: Flow<DebugOverlayPanelMetrics?>
-    get() = sharedMetrics
+  override val thermalState: Flow<ThermalState> = thermalDataSource.thermalState()
+    .shareIn(overlayScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 1_000), replay = 1)
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
@@ -78,15 +78,22 @@ private fun Int.toThermalStatus(): ThermalStatus = when (this) {
  * Data source for [ThermalState] derived from [PowerManager] thermal APIs.
  *
  * Requires Android 11 (API 30) or above. On older devices the data source emits a single
- * [ThermalStatus.UNSUPPORTED] state and stays open. On API 30+ devices with an incomplete
- * thermal HAL (initial [PowerManager.getThermalHeadroom] returns `NaN` or `0`), the data
- * source likewise emits [ThermalStatus.UNSUPPORTED].
+ * [ThermalStatus.UNSUPPORTED] state and stays open.
  *
- * On supported devices, status is derived from a hybrid of:
+ * On API 30+ devices, status is derived from a hybrid of:
  *  - [PowerManager.getCurrentThermalStatus] (push-based via [PowerManager.OnThermalStatusChangedListener])
  *  - [PowerManager.getThermalHeadroom] (polled every [pollInterval]) — used as a fallback signal
  *    when the reported status is [PowerManager.THERMAL_STATUS_NONE], following Google's
  *    recommendation for devices whose thermal HAL is not fully implemented.
+ *
+ * Note: per Google's ADPF docs, [PowerManager.getThermalHeadroom] can return `NaN` shortly
+ * after boot before the HAL accumulates enough thermal samples. We do NOT classify the device
+ * as [ThermalStatus.UNSUPPORTED] in that case — [deriveThermalStatus] treats `NaN` as
+ * [ThermalStatus.NONE], and subsequent polls naturally pick up the real reading once (and if)
+ * the HAL warms up. Typical Pixel devices stabilise within ~30–60 seconds; OEM builds with a
+ * degraded or stub HAL may stay at `NaN` indefinitely. The trade-off: devices with a
+ * permanently broken thermal HAL will report `NONE` for the lifetime of the process instead
+ * of being hidden.
  */
 internal class ThermalDataSource(
   private val context: Context,
@@ -95,19 +102,11 @@ internal class ThermalDataSource(
 
   private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
 
-  /**
-   * `true` when the device runs API 30+ AND the thermal HAL is wired up
-   * (initial headroom reading is neither `NaN` nor `0`).
-   */
-  val isSupported: Boolean by lazy {
-    isApiLevelSupported() && hasUsableHeadroom()
-  }
-
   fun thermalState(): Flow<ThermalState> {
-    if (!isSupported) {
+    if (!isApiLevelSupported()) {
       return flowOf(ThermalState(ThermalStatus.UNSUPPORTED))
     }
-    @Suppress("NewApi") // isSupported implies SDK_INT >= R
+    @Suppress("NewApi") // isApiLevelSupported implies SDK_INT >= R
     return supportedThermalState()
   }
 
@@ -120,25 +119,27 @@ internal class ThermalDataSource(
   @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
   private fun isApiLevelSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 
-  @Suppress("NewApi") // Guarded by isApiLevelSupported
-  private fun hasUsableHeadroom(): Boolean {
-    if (!isApiLevelSupported()) return false
-    return runCatchingNonCancellation {
-      val initial = powerManager.getThermalHeadroom(0)
-      !initial.isNaN() && initial != 0f
-    }.getOrElse { e ->
-      Logger.w("getThermalHeadroom probe failed", e)
-      false
-    }
-  }
-
   @RequiresApi(Build.VERSION_CODES.R)
   private fun statusFlow(): Flow<Int> = callbackFlow {
     val listener = PowerManager.OnThermalStatusChangedListener { status -> trySend(status) }
     // Register the listener BEFORE the seed read so a concurrent thermal-status change between
     // the read and the registration is not silently dropped. A duplicate emission (seed + push
     // with the same value) is harmless — downstream uses shareIn(replay=1) / combine semantics.
-    powerManager.addThermalStatusListener(ContextCompat.getMainExecutor(context), listener)
+    val registered = runCatchingNonCancellation {
+      powerManager.addThermalStatusListener(ContextCompat.getMainExecutor(context), listener)
+    }.isSuccess
+    if (!registered) {
+      // Listener registration can throw in test environments (notably Robolectric, which does
+      // not shadow the (Executor, OnThermalStatusChangedListener) overload) and conceivably on
+      // OEM builds with a stub PowerManagerService. Degrade gracefully: emit a single NONE so
+      // combine() has a status seed, then keep the channel open. headroomFlow continues to
+      // poll, and deriveThermalStatus consults headroom whenever rawStatus == NONE — so the
+      // row still reflects throttling via the headroom heuristic.
+      Logger.w("addThermalStatusListener failed; falling back to headroom-only thermal signal")
+      trySend(PowerManager.THERMAL_STATUS_NONE)
+      awaitClose { /* nothing to unregister */ }
+      return@callbackFlow
+    }
     trySend(powerManager.currentThermalStatus)
     awaitClose { powerManager.removeThermalStatusListener(listener) }
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
@@ -1,0 +1,161 @@
+package com.ms.square.debugoverlay.internal.data.source
+
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import com.ms.square.debugoverlay.internal.Logger
+import com.ms.square.debugoverlay.internal.data.model.ThermalState
+import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
+import com.ms.square.debugoverlay.internal.util.runCatchingNonCancellation
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.isActive
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Heuristic thresholds for deriving a synthetic [ThermalStatus] from a [PowerManager.getThermalHeadroom]
+ * reading when [PowerManager.getCurrentThermalStatus] reports [PowerManager.THERMAL_STATUS_NONE].
+ *
+ * Mirrors the example in the Android ADPF documentation:
+ * https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api
+ *
+ * Note on the SEVERE bound: the Javadoc for [PowerManager.getThermalHeadroom] states that `1.0`
+ * indicates the SEVERE throttling threshold, so we treat `>= 1.0f` as SEVERE (slightly tighter
+ * than the doc's `> 1.0` pseudocode example).
+ */
+private const val HEADROOM_SEVERE = 1.0f
+private const val HEADROOM_MODERATE = 0.95f
+private const val HEADROOM_LIGHT = 0.85f
+
+/**
+ * Headroom poll interval. Google's ADPF documentation recommends not calling
+ * [PowerManager.getThermalHeadroom] more than once every 10 seconds; faster polls
+ * may return `NaN`.
+ * https://developer.android.com/games/optimize/adpf/thermal#java
+ */
+internal val DEFAULT_THERMAL_POLL_INTERVAL: Duration = 10L.seconds
+
+/**
+ * Maps a raw thermal status int plus a headroom reading to a [ThermalStatus].
+ *
+ * When the platform reports a status above [PowerManager.THERMAL_STATUS_NONE] it is trusted.
+ * Otherwise the headroom value is consulted; values above the [HEADROOM_LIGHT] threshold
+ * synthesize a corresponding status (per Google's pseudocode in the ADPF docs).
+ *
+ * Pure function — extracted for testability.
+ */
+internal fun deriveThermalStatus(rawStatus: Int, headroom: Float): ThermalStatus = when {
+  rawStatus > PowerManager.THERMAL_STATUS_NONE -> rawStatus.toThermalStatus()
+  headroom.isNaN() -> ThermalStatus.NONE
+  headroom >= HEADROOM_SEVERE -> ThermalStatus.SEVERE
+  headroom > HEADROOM_MODERATE -> ThermalStatus.MODERATE
+  headroom > HEADROOM_LIGHT -> ThermalStatus.LIGHT
+  else -> ThermalStatus.NONE
+}
+
+private fun Int.toThermalStatus(): ThermalStatus = when (this) {
+  PowerManager.THERMAL_STATUS_NONE -> ThermalStatus.NONE
+  PowerManager.THERMAL_STATUS_LIGHT -> ThermalStatus.LIGHT
+  PowerManager.THERMAL_STATUS_MODERATE -> ThermalStatus.MODERATE
+  PowerManager.THERMAL_STATUS_SEVERE -> ThermalStatus.SEVERE
+  PowerManager.THERMAL_STATUS_CRITICAL -> ThermalStatus.CRITICAL
+  PowerManager.THERMAL_STATUS_EMERGENCY -> ThermalStatus.EMERGENCY
+  PowerManager.THERMAL_STATUS_SHUTDOWN -> ThermalStatus.SHUTDOWN
+  else -> ThermalStatus.NONE
+}
+
+/**
+ * Data source for [ThermalState] derived from [PowerManager] thermal APIs.
+ *
+ * Requires Android 11 (API 30) or above. On older devices the data source emits a single
+ * [ThermalStatus.UNSUPPORTED] state and stays open. On API 30+ devices with an incomplete
+ * thermal HAL (initial [PowerManager.getThermalHeadroom] returns `NaN` or `0`), the data
+ * source likewise emits [ThermalStatus.UNSUPPORTED].
+ *
+ * On supported devices, status is derived from a hybrid of:
+ *  - [PowerManager.getCurrentThermalStatus] (push-based via [PowerManager.OnThermalStatusChangedListener])
+ *  - [PowerManager.getThermalHeadroom] (polled every [pollInterval]) — used as a fallback signal
+ *    when the reported status is [PowerManager.THERMAL_STATUS_NONE], following Google's
+ *    recommendation for devices whose thermal HAL is not fully implemented.
+ */
+internal class ThermalDataSource(
+  private val context: Context,
+  private val pollInterval: Duration = DEFAULT_THERMAL_POLL_INTERVAL,
+) {
+
+  private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+  /**
+   * `true` when the device runs API 30+ AND the thermal HAL is wired up
+   * (initial headroom reading is neither `NaN` nor `0`).
+   */
+  val isSupported: Boolean by lazy {
+    isApiLevelSupported() && hasUsableHeadroom()
+  }
+
+  fun thermalState(): Flow<ThermalState> {
+    if (!isSupported) {
+      return flowOf(ThermalState(ThermalStatus.UNSUPPORTED))
+    }
+    @Suppress("NewApi") // isSupported implies SDK_INT >= R
+    return supportedThermalState()
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun supportedThermalState(): Flow<ThermalState> =
+    combine(statusFlow(), headroomFlow()) { rawStatus, headroom ->
+      ThermalState(deriveThermalStatus(rawStatus, headroom))
+    }
+
+  @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
+  private fun isApiLevelSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
+  @Suppress("NewApi") // Guarded by isApiLevelSupported
+  private fun hasUsableHeadroom(): Boolean {
+    if (!isApiLevelSupported()) return false
+    return runCatchingNonCancellation {
+      val initial = powerManager.getThermalHeadroom(0)
+      !initial.isNaN() && initial != 0f
+    }.getOrElse { e ->
+      Logger.w("getThermalHeadroom probe failed", e)
+      false
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun statusFlow(): Flow<Int> = callbackFlow {
+    val listener = PowerManager.OnThermalStatusChangedListener { status -> trySend(status) }
+    // Register the listener BEFORE the seed read so a concurrent thermal-status change between
+    // the read and the registration is not silently dropped. A duplicate emission (seed + push
+    // with the same value) is harmless — downstream uses shareIn(replay=1) / combine semantics.
+    powerManager.addThermalStatusListener(ContextCompat.getMainExecutor(context), listener)
+    trySend(powerManager.currentThermalStatus)
+    awaitClose { powerManager.removeThermalStatusListener(listener) }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun headroomFlow(): Flow<Float> = flow {
+    while (currentCoroutineContext().isActive) {
+      emit(readHeadroom())
+      delay(pollInterval)
+    }
+  }
+
+  @Suppress("NewApi") // Guarded by isApiLevelSupported at call sites
+  private fun readHeadroom(): Float = runCatchingNonCancellation {
+    powerManager.getThermalHeadroom(0)
+  }.getOrElse { e ->
+    Logger.w("getThermalHeadroom read failed", e)
+    Float.NaN
+  }
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSource.kt
@@ -56,7 +56,12 @@ internal val DEFAULT_THERMAL_POLL_INTERVAL: Duration = 10L.seconds
  */
 internal fun deriveThermalStatus(rawStatus: Int, headroom: Float): ThermalStatus = when {
   rawStatus > PowerManager.THERMAL_STATUS_NONE -> rawStatus.toThermalStatus()
-  headroom.isNaN() -> ThermalStatus.NONE
+  // Per the Javadoc for getThermalHeadroom, NaN means either "device does not support this
+  // functionality" or "called significantly faster than once per second". We poll at 10s
+  // intervals (well within the rate limit), so NaN in our use case means the device's thermal
+  // HAL does not expose headroom — treat as unsupported so the UI hides the row. If the HAL
+  // ever starts returning real values, this self-heals on the next emission.
+  headroom.isNaN() -> ThermalStatus.UNSUPPORTED
   headroom >= HEADROOM_SEVERE -> ThermalStatus.SEVERE
   headroom > HEADROOM_MODERATE -> ThermalStatus.MODERATE
   headroom > HEADROOM_LIGHT -> ThermalStatus.LIGHT
@@ -78,7 +83,9 @@ private fun Int.toThermalStatus(): ThermalStatus = when (this) {
  * Data source for [ThermalState] derived from [PowerManager] thermal APIs.
  *
  * Requires Android 11 (API 30) or above. On older devices the data source emits a single
- * [ThermalStatus.UNSUPPORTED] state and stays open.
+ * [ThermalStatus.UNSUPPORTED] state via `flowOf(...)` and completes. Downstream consumers
+ * that wrap this in `shareIn(replay = 1)` (e.g. `DebugOverlayPanelDataSource`) will continue
+ * to surface that last value to new subscribers.
  *
  * On API 30+ devices, status is derived from a hybrid of:
  *  - [PowerManager.getCurrentThermalStatus] (push-based via [PowerManager.OnThermalStatusChangedListener])
@@ -86,14 +93,12 @@ private fun Int.toThermalStatus(): ThermalStatus = when (this) {
  *    when the reported status is [PowerManager.THERMAL_STATUS_NONE], following Google's
  *    recommendation for devices whose thermal HAL is not fully implemented.
  *
- * Note: per Google's ADPF docs, [PowerManager.getThermalHeadroom] can return `NaN` shortly
- * after boot before the HAL accumulates enough thermal samples. We do NOT classify the device
- * as [ThermalStatus.UNSUPPORTED] in that case — [deriveThermalStatus] treats `NaN` as
- * [ThermalStatus.NONE], and subsequent polls naturally pick up the real reading once (and if)
- * the HAL warms up. Typical Pixel devices stabilise within ~30–60 seconds; OEM builds with a
- * degraded or stub HAL may stay at `NaN` indefinitely. The trade-off: devices with a
- * permanently broken thermal HAL will report `NONE` for the lifetime of the process instead
- * of being hidden.
+ * Per the [PowerManager.getThermalHeadroom] Javadoc, `NaN` means either "device does not
+ * support this functionality" or "called significantly faster than once per second". Our
+ * 10-second polling sits well within the rate limit, so a persistent `NaN` is treated as
+ * "unsupported": [deriveThermalStatus] maps the `NaN` case to [ThermalStatus.UNSUPPORTED]
+ * and the UI hides the row. If the HAL later starts returning real values, the next
+ * emission self-heals and the row reappears.
  */
 internal class ThermalDataSource(
   private val context: Context,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -1,17 +1,23 @@
-@file:Suppress("MagicNumber")
+@file:Suppress("MagicNumber", "TooManyFunctions")
 
 package com.ms.square.debugoverlay.internal.ui
 
 import android.view.HapticFeedbackConstants
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +28,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -29,11 +36,15 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.DebugOverlayPanelMetrics
 import com.ms.square.debugoverlay.internal.data.model.Metrics
+import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
 
@@ -44,6 +55,7 @@ private val STATUS_COLOR_CRITICAL = Color(0xFFF44336)
 @Composable
 internal fun DraggableOverlayPanel(
   metrics: DebugOverlayPanelMetrics?,
+  showThermal: Boolean,
   initialOffsetX: Float,
   initialOffsetY: Float,
   modifier: Modifier = Modifier,
@@ -100,13 +112,18 @@ internal fun DraggableOverlayPanel(
       }
   ) {
     DebugOverlayPanel(
-      metrics = metrics
+      metrics = metrics,
+      showThermal = showThermal
     )
   }
 }
 
 @Composable
-internal fun DebugOverlayPanel(metrics: DebugOverlayPanelMetrics?, modifier: Modifier = Modifier) {
+internal fun DebugOverlayPanel(
+  metrics: DebugOverlayPanelMetrics?,
+  modifier: Modifier = Modifier,
+  showThermal: Boolean = false,
+) {
   // Disable font scaling to maintain consistent overlay panel size regardless of system font settings.
   // Debug overlay panel is for developers, so not supporting font scaling is acceptable.
   CompositionLocalProvider(
@@ -138,6 +155,9 @@ internal fun DebugOverlayPanel(metrics: DebugOverlayPanelMetrics?, modifier: Mod
           HeapRow(it.heapMetrics)
           PssRow(it.pssMetrics, it.maxPss)
           FpsRow(it.fpsMetrics, it.targetFps, it.maxFps)
+          if (showThermal && it.thermalState.status != ThermalStatus.UNSUPPORTED) {
+            ThermalRow(it.thermalState.status)
+          }
         }
       }
     }
@@ -221,4 +241,57 @@ private fun Float.toMemPssStatusColor(): Color = when {
   this > 750 -> STATUS_COLOR_CRITICAL
   this > 500 -> STATUS_COLOR_WARNING
   else -> STATUS_COLOR_NORMAL
+}
+
+@Composable
+private fun ThermalRow(status: ThermalStatus) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Box(
+        modifier = Modifier
+          .size(6.dp)
+          .background(status.toStatusColor(), CircleShape)
+      )
+      Text(
+        text = stringResource(R.string.debugoverlay_thermal_compact_label),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+    Text(
+      text = stringResource(status.compactLabelResId()),
+      style = MaterialTheme.typography.titleSmall,
+      color = MaterialTheme.colorScheme.onSurface,
+      fontWeight = FontWeight.SemiBold
+    )
+  }
+}
+
+private fun ThermalStatus.toStatusColor(): Color = when (this) {
+  ThermalStatus.NONE, ThermalStatus.LIGHT -> STATUS_COLOR_NORMAL
+  ThermalStatus.MODERATE, ThermalStatus.SEVERE -> STATUS_COLOR_WARNING
+  ThermalStatus.CRITICAL,
+  ThermalStatus.EMERGENCY,
+  ThermalStatus.SHUTDOWN,
+  -> STATUS_COLOR_CRITICAL
+  ThermalStatus.UNSUPPORTED -> STATUS_COLOR_NORMAL
+}
+
+private fun ThermalStatus.compactLabelResId(): Int = when (this) {
+  ThermalStatus.NONE -> R.string.debugoverlay_thermal_status_none_abbr
+  ThermalStatus.LIGHT -> R.string.debugoverlay_thermal_status_light_abbr
+  ThermalStatus.MODERATE -> R.string.debugoverlay_thermal_status_moderate_abbr
+  ThermalStatus.SEVERE -> R.string.debugoverlay_thermal_status_severe_abbr
+  ThermalStatus.CRITICAL -> R.string.debugoverlay_thermal_status_critical_abbr
+  ThermalStatus.EMERGENCY -> R.string.debugoverlay_thermal_status_emergency_abbr
+  ThermalStatus.SHUTDOWN -> R.string.debugoverlay_thermal_status_shutdown_abbr
+  // Defensive fallback; ThermalRow is hidden when status is UNSUPPORTED so this never renders.
+  ThermalStatus.UNSUPPORTED -> R.string.debugoverlay_thermal_status_none_abbr
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.DebugOverlayPanelMetrics
 import com.ms.square.debugoverlay.internal.data.model.Metrics
+import com.ms.square.debugoverlay.internal.data.model.ThermalState
 import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
@@ -55,7 +56,7 @@ private val STATUS_COLOR_CRITICAL = Color(0xFFF44336)
 @Composable
 internal fun DraggableOverlayPanel(
   metrics: DebugOverlayPanelMetrics?,
-  showThermal: Boolean,
+  thermalState: ThermalState?,
   initialOffsetX: Float,
   initialOffsetY: Float,
   modifier: Modifier = Modifier,
@@ -113,7 +114,7 @@ internal fun DraggableOverlayPanel(
   ) {
     DebugOverlayPanel(
       metrics = metrics,
-      showThermal = showThermal
+      thermalState = thermalState
     )
   }
 }
@@ -122,7 +123,7 @@ internal fun DraggableOverlayPanel(
 internal fun DebugOverlayPanel(
   metrics: DebugOverlayPanelMetrics?,
   modifier: Modifier = Modifier,
-  showThermal: Boolean = false,
+  thermalState: ThermalState? = null,
 ) {
   // Disable font scaling to maintain consistent overlay panel size regardless of system font settings.
   // Debug overlay panel is for developers, so not supporting font scaling is acceptable.
@@ -155,8 +156,8 @@ internal fun DebugOverlayPanel(
           HeapRow(it.heapMetrics)
           PssRow(it.pssMetrics, it.maxPss)
           FpsRow(it.fpsMetrics, it.targetFps, it.maxFps)
-          if (showThermal && it.thermalState.status != ThermalStatus.UNSUPPORTED) {
-            ThermalRow(it.thermalState.status)
+          if (thermalState != null && thermalState.status != ThermalStatus.UNSUPPORTED) {
+            ThermalRow(thermalState.status)
           }
         }
       }
@@ -243,6 +244,10 @@ private fun Float.toMemPssStatusColor(): Color = when {
   else -> STATUS_COLOR_NORMAL
 }
 
+/**
+ * Bespoke row layout (no `MetricRow` / `LineGraph`) because thermal status is a categorical
+ * enum rather than a continuous time-series — a sparkline would have nothing meaningful to plot.
+ */
 @Composable
 private fun ThermalRow(status: ThermalStatus) {
   Row(

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -152,6 +152,16 @@
   <string name="debugoverlay_device_info_percentage_value">%d%% free</string>
   <string name="debugoverlay_device_info_hz_value">%.0f Hz/%.0f Hz</string>
 
+  <!-- Thermal (compact overlay row, opt-in via OverlayMode.FullMetrics(showThermal = true)) -->
+  <string name="debugoverlay_thermal_compact_label">Therm</string>
+  <string name="debugoverlay_thermal_status_none_abbr">None</string>
+  <string name="debugoverlay_thermal_status_light_abbr">Light</string>
+  <string name="debugoverlay_thermal_status_moderate_abbr">Mod</string>
+  <string name="debugoverlay_thermal_status_severe_abbr">Sev</string>
+  <string name="debugoverlay_thermal_status_critical_abbr">Crit</string>
+  <string name="debugoverlay_thermal_status_emergency_abbr">Emer</string>
+  <string name="debugoverlay_thermal_status_shutdown_abbr">Shut</string>
+
   <!-- Bug Report -->
   <string name="debugoverlay_bug_report">Generate Bug Report</string>
   <string name="debugoverlay_bug_report_generating">Generating bug report</string>

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
@@ -16,9 +16,12 @@ import org.robolectric.annotation.Config
  * Tests for [ThermalDataSource] and its [deriveThermalStatus] helper.
  *
  * Robolectric does not shadow [android.os.PowerManager.getThermalHeadroom]; the call falls
- * through to a real (unimplemented) HAL that returns `0` / `NaN`. That mirrors a device with
- * an incomplete thermal HAL, which the data source should treat as `UNSUPPORTED` per Google's
- * ADPF guidance:
+ * through to a real (unimplemented) HAL that returns `0` / `NaN`. Per the Javadoc contract,
+ * `NaN` (at our 10s polling rate) means the device does not support thermal headroom, so
+ * the data source emits [ThermalStatus.UNSUPPORTED] and the UI hides the row. The state
+ * self-heals to a real level if the HAL later starts returning data.
+ *
+ * See Google's ADPF guidance:
  * https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api
  */
 @RunWith(RobolectricTestRunner::class)
@@ -29,14 +32,14 @@ class ThermalDataSourceTest {
 
   //region ThermalDataSource — API gate / graceful degradation
   @Test
-  fun `thermalState emits NONE on API 30+ when HAL has no headroom data yet`() = runTest {
+  fun `thermalState emits UNSUPPORTED on API 30+ when headroom HAL is not present`() = runTest {
     // Robolectric defaults to a modern API level (>= R) with a non-shadowed thermal HAL.
-    // PowerManager returns THERMAL_STATUS_NONE and getThermalHeadroom returns 0/NaN — this
-    // mirrors a real device whose HAL hasn't warmed up yet. The data source must emit NONE
-    // (not UNSUPPORTED) so the row recovers gracefully once the HAL produces real readings.
+    // getThermalHeadroom returns NaN, which per the Javadoc means "device does not support
+    // this functionality" (we poll at 10s, so the rate-limit case doesn't apply). The data
+    // source must emit UNSUPPORTED so the UI hides the row.
     val state = dataSource.thermalState().first()
 
-    assertThat(state.status).isEqualTo(ThermalStatus.NONE)
+    assertThat(state.status).isEqualTo(ThermalStatus.UNSUPPORTED)
   }
 
   @Test
@@ -114,10 +117,11 @@ class ThermalDataSourceTest {
   }
 
   @Test
-  fun `deriveThermalStatus returns NONE when raw is NONE and headroom is NaN`() {
-    // NaN from getThermalHeadroom must not promote to a synthetic status.
+  fun `deriveThermalStatus returns UNSUPPORTED when raw is NONE and headroom is NaN`() {
+    // Per the Javadoc, NaN at our 10s polling rate means the device does not support thermal
+    // headroom — emit UNSUPPORTED so the UI hides the row rather than misleadingly showing NONE.
     assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = Float.NaN))
-      .isEqualTo(ThermalStatus.NONE)
+      .isEqualTo(ThermalStatus.UNSUPPORTED)
   }
   //endregion
 }

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
@@ -1,5 +1,6 @@
 package com.ms.square.debugoverlay.internal.data.source
 
+import android.os.Build
 import android.os.PowerManager
 import com.google.common.truth.Truth.assertThat
 import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
@@ -9,6 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 /**
  * Tests for [ThermalDataSource] and its [deriveThermalStatus] helper.
@@ -25,15 +27,24 @@ class ThermalDataSourceTest {
   private val context = RuntimeEnvironment.getApplication()
   private val dataSource = ThermalDataSource(context)
 
-  //region ThermalDataSource — support detection / graceful degradation
+  //region ThermalDataSource — API gate / graceful degradation
   @Test
-  fun `isSupported is false on devices where headroom probe fails`() {
-    assertThat(dataSource.isSupported).isFalse()
+  fun `thermalState emits NONE on API 30+ when HAL has no headroom data yet`() = runTest {
+    // Robolectric defaults to a modern API level (>= R) with a non-shadowed thermal HAL.
+    // PowerManager returns THERMAL_STATUS_NONE and getThermalHeadroom returns 0/NaN — this
+    // mirrors a real device whose HAL hasn't warmed up yet. The data source must emit NONE
+    // (not UNSUPPORTED) so the row recovers gracefully once the HAL produces real readings.
+    val state = dataSource.thermalState().first()
+
+    assertThat(state.status).isEqualTo(ThermalStatus.NONE)
   }
 
   @Test
-  fun `thermalState emits UNSUPPORTED when device has no usable thermal HAL`() = runTest {
-    val state = dataSource.thermalState().first()
+  @Config(sdk = [Build.VERSION_CODES.P])
+  fun `thermalState emits UNSUPPORTED on devices below API 30`() = runTest {
+    val preApi30Source = ThermalDataSource(context)
+
+    val state = preApi30Source.thermalState().first()
 
     assertThat(state.status).isEqualTo(ThermalStatus.UNSUPPORTED)
   }

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/data/source/ThermalDataSourceTest.kt
@@ -1,0 +1,112 @@
+package com.ms.square.debugoverlay.internal.data.source
+
+import android.os.PowerManager
+import com.google.common.truth.Truth.assertThat
+import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Tests for [ThermalDataSource] and its [deriveThermalStatus] helper.
+ *
+ * Robolectric does not shadow [android.os.PowerManager.getThermalHeadroom]; the call falls
+ * through to a real (unimplemented) HAL that returns `0` / `NaN`. That mirrors a device with
+ * an incomplete thermal HAL, which the data source should treat as `UNSUPPORTED` per Google's
+ * ADPF guidance:
+ * https://developer.android.com/games/optimize/adpf/thermal#device-limitations-of-the-thermal-api
+ */
+@RunWith(RobolectricTestRunner::class)
+class ThermalDataSourceTest {
+
+  private val context = RuntimeEnvironment.getApplication()
+  private val dataSource = ThermalDataSource(context)
+
+  //region ThermalDataSource — support detection / graceful degradation
+  @Test
+  fun `isSupported is false on devices where headroom probe fails`() {
+    assertThat(dataSource.isSupported).isFalse()
+  }
+
+  @Test
+  fun `thermalState emits UNSUPPORTED when device has no usable thermal HAL`() = runTest {
+    val state = dataSource.thermalState().first()
+
+    assertThat(state.status).isEqualTo(ThermalStatus.UNSUPPORTED)
+  }
+  //endregion
+
+  //region deriveThermalStatus — rawStatus takes precedence when above NONE
+  @Test
+  fun `deriveThermalStatus uses raw status when above NONE regardless of headroom`() {
+    // Even a benign headroom should not downgrade an explicit SEVERE reading from the platform.
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_SEVERE, headroom = 0.1f))
+      .isEqualTo(ThermalStatus.SEVERE)
+  }
+
+  @Test
+  fun `deriveThermalStatus maps each raw status code to its enum`() {
+    val cases = mapOf(
+      PowerManager.THERMAL_STATUS_NONE to ThermalStatus.NONE,
+      PowerManager.THERMAL_STATUS_LIGHT to ThermalStatus.LIGHT,
+      PowerManager.THERMAL_STATUS_MODERATE to ThermalStatus.MODERATE,
+      PowerManager.THERMAL_STATUS_SEVERE to ThermalStatus.SEVERE,
+      PowerManager.THERMAL_STATUS_CRITICAL to ThermalStatus.CRITICAL,
+      PowerManager.THERMAL_STATUS_EMERGENCY to ThermalStatus.EMERGENCY,
+      PowerManager.THERMAL_STATUS_SHUTDOWN to ThermalStatus.SHUTDOWN
+    )
+    cases.forEach { (raw, expected) ->
+      // Headroom 0.5 is irrelevant when raw > NONE; only matters in the NONE fallback path.
+      assertThat(deriveThermalStatus(raw, headroom = 0.5f)).isEqualTo(expected)
+    }
+  }
+
+  @Test
+  fun `deriveThermalStatus falls back to NONE for unknown raw status when headroom is benign`() {
+    assertThat(deriveThermalStatus(rawStatus = 99, headroom = 0.5f)).isEqualTo(ThermalStatus.NONE)
+  }
+  //endregion
+
+  //region deriveThermalStatus — headroom fallback (when raw == NONE)
+  @Test
+  fun `deriveThermalStatus returns NONE when both signals are benign`() {
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = 0.5f))
+      .isEqualTo(ThermalStatus.NONE)
+  }
+
+  @Test
+  fun `deriveThermalStatus returns LIGHT when headroom exceeds 0_85 threshold`() {
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = 0.86f))
+      .isEqualTo(ThermalStatus.LIGHT)
+  }
+
+  @Test
+  fun `deriveThermalStatus returns MODERATE when headroom exceeds 0_95 threshold`() {
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = 0.96f))
+      .isEqualTo(ThermalStatus.MODERATE)
+  }
+
+  @Test
+  fun `deriveThermalStatus returns SEVERE when headroom equals 1_0 exactly`() {
+    // Per the Javadoc for getThermalHeadroom: "1.0 indicates the SEVERE throttling threshold."
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = 1.0f))
+      .isEqualTo(ThermalStatus.SEVERE)
+  }
+
+  @Test
+  fun `deriveThermalStatus returns SEVERE when headroom exceeds 1_0`() {
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = 1.05f))
+      .isEqualTo(ThermalStatus.SEVERE)
+  }
+
+  @Test
+  fun `deriveThermalStatus returns NONE when raw is NONE and headroom is NaN`() {
+    // NaN from getThermalHeadroom must not promote to a synthetic status.
+    assertThat(deriveThermalStatus(PowerManager.THERMAL_STATUS_NONE, headroom = Float.NaN))
+      .isEqualTo(ThermalStatus.NONE)
+  }
+  //endregion
+}

--- a/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
+++ b/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
@@ -21,8 +21,14 @@ object DebugOverlaySetup {
     // Swap to OverlayMode.Hidden(customTabs) to hide the on-screen overlay entirely
     // and trigger the panel via DebugOverlay.openPanel(context) — see "Open Debug Panel"
     // card on the Overlay Tests screen.
+    //
+    // showThermal = true adds a thermal-status row to the compact overlay. Requires Android 11+
+    // with a fully implemented thermal HAL; on unsupported devices the row stays hidden.
     DebugOverlay.configure {
-      overlayMode = OverlayMode.FullMetrics(customTabs = customTabs)
+      overlayMode = OverlayMode.FullMetrics(
+        customTabs = customTabs,
+        showThermal = true
+      )
     }
 
     // Also contribute the same data to bug reports

--- a/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
+++ b/sample/src/debugOverlay/kotlin/com/ms/square/debugoverlay/sample/DebugOverlaySetup.kt
@@ -23,7 +23,8 @@ object DebugOverlaySetup {
     // card on the Overlay Tests screen.
     //
     // showThermal = true adds a thermal-status row to the compact overlay. Requires Android 11+
-    // with a fully implemented thermal HAL; on unsupported devices the row stays hidden.
+    // with a working thermal HAL; the row stays hidden on older devices and on devices whose
+    // HAL doesn't expose getThermalHeadroom data.
     DebugOverlay.configure {
       overlayMode = OverlayMode.FullMetrics(
         customTabs = customTabs,

--- a/sample/src/main/kotlin/com/ms/square/debugoverlay/sample/ui/overlaytests/OverlayTestsScreen.kt
+++ b/sample/src/main/kotlin/com/ms/square/debugoverlay/sample/ui/overlaytests/OverlayTestsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.VerticalAlignBottom
 import androidx.compose.material.icons.filled.ViewAgenda
 import androidx.compose.material.icons.filled.Visibility
@@ -46,7 +47,7 @@ import com.ms.square.debugoverlay.sample.SecondActivity
  * Main screen for overlay test scenarios.
  * Displays categorized test scenarios to validate overlay z-order behavior.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun OverlayTestsScreen(modifier: Modifier = Modifier) {
@@ -59,6 +60,9 @@ internal fun OverlayTestsScreen(modifier: Modifier = Modifier) {
   var showComposeBottomSheet by rememberSaveable { mutableStateOf(false) }
   var isFullscreen by rememberSaveable { mutableStateOf(false) }
   var isOverlayHidden by rememberSaveable { mutableStateOf(false) }
+  // Matches DebugOverlaySetup.kt default; both this toggle and the Hide/Show Overlay toggle
+  // honor it so flipping visibility never silently changes the thermal preference.
+  var isThermalOn by rememberSaveable { mutableStateOf(true) }
 
   // Reset fullscreen mode when leaving the screen
   DisposableEffect(Unit) {
@@ -210,9 +214,29 @@ internal fun OverlayTestsScreen(modifier: Modifier = Modifier) {
           onClick = {
             val nextHidden = !isOverlayHidden
             DebugOverlay.configure {
-              overlayMode = if (nextHidden) OverlayMode.Hidden() else OverlayMode.FullMetrics()
+              overlayMode = if (nextHidden) OverlayMode.Hidden() else OverlayMode.FullMetrics(showThermal = isThermalOn)
             }
             isOverlayHidden = nextHidden
+          },
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+
+      item {
+        TestScenarioCard(
+          title = if (isThermalOn) "Hide Thermal Row" else "Show Thermal Row",
+          description = "Toggle the thermal-status row in the compact overlay (Android 11+ only)",
+          icon = Icons.Default.Thermostat,
+          onClick = {
+            val nextThermalOn = !isThermalOn
+            isThermalOn = nextThermalOn
+            // Only reconfigure when the overlay is currently shown — if hidden, the preference
+            // is recorded locally and applied next time the user shows the overlay.
+            if (!isOverlayHidden) {
+              DebugOverlay.configure {
+                overlayMode = OverlayMode.FullMetrics(showThermal = nextThermalOn)
+              }
+            }
           },
           modifier = Modifier.fillMaxWidth()
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional thermal status row to the compact debug overlay (Android 11+ with thermal HAL support). Enable via `OverlayMode.FullMetrics(showThermal = true)`. Displays device thermal throttling states: None, Light, Moderate, Severe, Critical, Emergency, and Shutdown.

* **Documentation**
  * Updated README and CHANGELOG with thermal status row configuration and usage instructions.

* **Tests**
  * Added comprehensive test coverage for thermal status monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Manabu-GT/DebugOverlay-Android/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->