### PR TITLE
docs: update README for v2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.5.0")
+debugImplementation("com.ms-square:debugoverlay:2.6.0")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -73,7 +73,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.5.0"
+debugoverlay = "2.6.0"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -99,7 +99,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.0")
 }
 ```
 
@@ -154,8 +154,8 @@ For a zero-config shake trigger, add the shake extension:
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.5.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.0")
 }
 ```
 
@@ -207,8 +207,8 @@ The value also bounds the `logcat -T N` / `-t N` calls, so it caps how many line
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.5.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.0")
 }
 ```
 
@@ -239,8 +239,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.5.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.5.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.0")
 }
 ```
 
@@ -364,7 +364,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.5.0")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.0")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Bumped install snippets from `2.5.0` to `2.6.0` across Quick Start, Version Catalog, Kotlin DSL, the OkHttp / Timber / shake-trigger extensions, and the `releaseWithOverlay` example.

## Test plan
- [x] Verify rendered README on GitHub shows `2.6.0` in every code snippet
- [x] Confirm no stale `2.5.0` references remain (`grep -n "2\.5\.0" README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)