### PR TITLE
docs: update README for v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 2.6.1 *(2026-05-21)*
+
+### Bug Fixes
+
+* **Speculative fix for "Create Report" being unresponsive on Xiaomi / MIUI** – `BugReportActivity` is no longer launched with `FLAG_ACTIVITY_NEW_TASK` when invoked from an Activity context; the flag is preserved for the FAB's non-Activity overlay context where it is still required. The combination of `NEW_TASK` + a transparent destination is suspected of tripping MIUI's pop-up window gate, but the symptom reported in [#251](https://github.com/Manabu-GT/DebugOverlay-Android/issues/251) could not be reproduced on the maintainer's devices, so this is an exploratory change rather than a verified fix.
+
 ## Version 2.6.0 *(2026-05-18)*
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.6.0")
+debugImplementation("com.ms-square:debugoverlay:2.6.1")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -73,7 +73,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.6.0"
+debugoverlay = "2.6.1"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -99,7 +99,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.1")
 }
 ```
 
@@ -154,8 +154,8 @@ For a zero-config shake trigger, add the shake extension:
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.1")
 }
 ```
 
@@ -207,8 +207,8 @@ The value also bounds the `logcat -T N` / `-t N` calls, so it caps how many line
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.1")
 }
 ```
 
@@ -239,8 +239,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.0")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.0")
+  debugImplementation("com.ms-square:debugoverlay:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.1")
 }
 ```
 
@@ -364,7 +364,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.0")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.1")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Bump dependency coordinate examples in README from `2.6.0` to `2.6.1`.
- Add CHANGELOG entry for v2.6.1 covering the speculative MIUI fix from #252; framed as exploratory since the symptom reported in #251 could not be reproduced on the maintainer's devices.

## Test plan
- [ ] Visual review of CHANGELOG wording (especially the "speculative / exploratory" framing).
- [ ] Verify all 10 README version references read `2.6.1` and that links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issue affecting Xiaomi/MIUI devices related to bug report activity launching, enhancing overall stability on these platforms.

* **Documentation**
  * Updated all installation guides and code examples to version 2.6.1, including Quick Start, Gradle, Kotlin DSL, and extension setup examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Manabu-GT/DebugOverlay-Android/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->