### PR TITLE
[fix] collapse Debug Panel filter bar on short-height windows (#257)

### DIFF
--- a/debugoverlay-core/build.gradle.kts
+++ b/debugoverlay-core/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
   implementation(libs.androidx.compose.foundation)
   implementation(libs.androidx.ui)
   implementation(libs.androidx.material3)
+  implementation(libs.androidx.material3.windowsizeclass)
   implementation(libs.androidx.ui.tooling.preview)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.compose.material.icons.extended)

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelActivity.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelActivity.kt
@@ -6,12 +6,16 @@ import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.ui.platform.LocalConfiguration
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.util.isDarkTheme
 
 public class DebugPanelActivity : ComponentActivity() {
 
+  @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -20,12 +24,15 @@ public class DebugPanelActivity : ComponentActivity() {
 
     setContent {
       val isDarkTheme = LocalConfiguration.current.isDarkTheme()
+      val windowSizeClass = calculateWindowSizeClass(this)
+      val isCompactHeight = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
 
       MaterialTheme(
         colorScheme = if (isDarkTheme) darkColorScheme() else lightColorScheme()
       ) {
         DebugPanelDialog(
-          onDismiss = { finish() }
+          onDismiss = { finish() },
+          isCompactHeight = isCompactHeight
         )
       }
     }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
@@ -347,7 +347,8 @@ private fun DebugPanelTabContent(
       )
       BuiltInTab.NETWORK -> NetworkTabContent(
         netStatsFlow = repository.netStats,
-        networkRequestsFlow = repository.networkRequests
+        networkRequestsFlow = repository.networkRequests,
+        isCompactHeight = isCompactHeight
       )
       BuiltInTab.JANKSTATS -> JankStatsTabContent(jankStatsFlow = repository.jankStats)
       BuiltInTab.UI -> UiTabContent()

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugPanelDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -80,8 +82,10 @@ private sealed class PanelTab {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun DebugPanelDialog(onDismiss: () -> Unit) {
+internal fun DebugPanelDialog(onDismiss: () -> Unit, isCompactHeight: Boolean = false) {
   val snackBarHostState = remember { SnackbarHostState() }
+  // Only collapse the top bar on scroll when vertical space is tight; otherwise keep it static.
+  val scrollBehavior = if (isCompactHeight) TopAppBarDefaults.enterAlwaysScrollBehavior() else null
 
   Dialog(
     onDismissRequest = onDismiss,
@@ -102,7 +106,9 @@ internal fun DebugPanelDialog(onDismiss: () -> Unit) {
     }
 
     Scaffold(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier
+        .fillMaxSize()
+        .let { if (scrollBehavior != null) it.nestedScroll(scrollBehavior.nestedScrollConnection) else it },
       containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
       snackbarHost = {
         SnackbarHost(hostState = snackBarHostState) { snackBarData ->
@@ -116,11 +122,13 @@ internal fun DebugPanelDialog(onDismiss: () -> Unit) {
       topBar = {
         DebugPanelTopAppBar(
           snackBarHostState = snackBarHostState,
-          onDismiss = onDismiss
+          onDismiss = onDismiss,
+          scrollBehavior = scrollBehavior
         )
       }
     ) { paddingValues ->
       DebugPanelContent(
+        isCompactHeight = isCompactHeight,
         modifier = Modifier
           .fillMaxSize()
           .padding(paddingValues)
@@ -136,6 +144,7 @@ private fun DebugPanelTopAppBar(
   bugReportGenerator: BugReportGenerator = DebugOverlay.bugReportGenerator,
   snackBarHostState: SnackbarHostState,
   onDismiss: () -> Unit,
+  scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
@@ -191,7 +200,8 @@ private fun DebugPanelTopAppBar(
     },
     colors = TopAppBarDefaults.topAppBarColors(
       containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    )
+    ),
+    scrollBehavior = scrollBehavior
   )
 }
 
@@ -252,7 +262,7 @@ private fun bugReportButtonDescription(isCapturing: Boolean, draftCount: Int) = 
 }
 
 @Composable
-private fun DebugPanelContent(modifier: Modifier = Modifier) {
+private fun DebugPanelContent(isCompactHeight: Boolean, modifier: Modifier = Modifier) {
   val repository = DebugOverlay.overlayDataRepository
   val hasCustomLogSource by repository.hasCustomLogSource.collectAsStateWithLifecycle()
   val customLogSourceName by repository.customLogSourceName.collectAsStateWithLifecycle()
@@ -278,7 +288,8 @@ private fun DebugPanelContent(modifier: Modifier = Modifier) {
     )
     DebugPanelTabContent(
       selectedTab = visibleTabs[selectedIndex],
-      repository = repository
+      repository = repository,
+      isCompactHeight = isCompactHeight
     )
   }
 }
@@ -318,11 +329,18 @@ private fun DebugPanelTabRow(
 }
 
 @Composable
-private fun DebugPanelTabContent(selectedTab: PanelTab, repository: DebugOverlayDataRepository) {
+private fun DebugPanelTabContent(
+  selectedTab: PanelTab,
+  repository: DebugOverlayDataRepository,
+  isCompactHeight: Boolean,
+) {
   when (selectedTab) {
     is PanelTab.BuiltIn -> when (selectedTab.tab) {
-      BuiltInTab.LOGCAT -> LogTabContent(logsFlow = repository.logcatLogs)
-      BuiltInTab.CUSTOM_LOG -> LogTabContent(logsFlow = repository.customLogSourceLogs)
+      BuiltInTab.LOGCAT -> LogTabContent(logsFlow = repository.logcatLogs, isCompactHeight = isCompactHeight)
+      BuiltInTab.CUSTOM_LOG -> LogTabContent(
+        logsFlow = repository.customLogSourceLogs,
+        isCompactHeight = isCompactHeight
+      )
       BuiltInTab.APP_EXITS -> AppExitTabContent(
         exitInfosFlow = repository.appExitInfos,
         isSupported = repository.isAppExitSupported

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogFilterBar.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogFilterBar.kt
@@ -1,0 +1,233 @@
+package com.ms.square.debugoverlay.internal.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.Badge
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.ms.square.debugoverlay.core.R
+import com.ms.square.debugoverlay.internal.util.toColor
+import com.ms.square.debugoverlay.model.LogLevel
+
+/**
+ * Filter bar for [LogTabContent]: a search field plus log-level filters.
+ *
+ * On short-height windows ([isCompactHeight]), collapses to [CompactLogFilterRow] to reclaim
+ * vertical space for the log list; otherwise renders the always-visible search field and
+ * filter-chip row.
+ */
+@Composable
+internal fun LogFilterBar(
+  searchQuery: String,
+  onSearchQueryChanged: (String) -> Unit,
+  selectedLevel: LogLevel,
+  onLevelSelected: (LogLevel) -> Unit,
+  isCompactHeight: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  if (isCompactHeight) {
+    CompactLogFilterRow(
+      searchQuery = searchQuery,
+      onSearchQueryChanged = onSearchQueryChanged,
+      selectedLevel = selectedLevel,
+      onLevelSelected = onLevelSelected,
+      modifier = modifier
+        .fillMaxWidth()
+        .padding(top = 8.dp)
+    )
+  } else {
+    Column(modifier = modifier.fillMaxWidth().padding(top = 8.dp)) {
+      SearchField(
+        searchPlaceholder = stringResource(R.string.debugoverlay_search_logs),
+        searchQuery = searchQuery,
+        onSearchQueryChanged = onSearchQueryChanged,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 8.dp)
+      )
+
+      LogLevelFilters(
+        selectedLevel = selectedLevel,
+        onLevelSelected = onLevelSelected
+      )
+    }
+  }
+}
+
+/**
+ * Compact-height variant of [LogFilterBar]: the search field and level filters share a single
+ * row (filters collapse into a dropdown menu) instead of stacking on two — reclaiming the
+ * vertical space [LogFilterBar]'s two-row layout would otherwise cost on short-height windows
+ * (e.g. landscape on a small device). The search field itself stays full width since landscape
+ * width isn't the constrained dimension here — only merging the rows saves height.
+ */
+@Composable
+private fun CompactLogFilterRow(
+  searchQuery: String,
+  onSearchQueryChanged: (String) -> Unit,
+  selectedLevel: LogLevel,
+  onLevelSelected: (LogLevel) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp)
+  ) {
+    SearchField(
+      searchPlaceholder = stringResource(R.string.debugoverlay_search_logs),
+      searchQuery = searchQuery,
+      onSearchQueryChanged = onSearchQueryChanged,
+      modifier = Modifier.weight(1f)
+    )
+
+    LogLevelFilterMenu(
+      selectedLevel = selectedLevel,
+      onLevelSelected = onLevelSelected
+    )
+  }
+}
+
+@Composable
+private fun LogLevelFilterMenu(
+  selectedLevel: LogLevel,
+  onLevelSelected: (LogLevel) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var isMenuExpanded by remember { mutableStateOf(false) }
+  val filterDescription = stringResource(R.string.debugoverlay_filter_logs_content_description)
+
+  Box(modifier = modifier) {
+    IconButton(
+      onClick = { isMenuExpanded = true },
+      modifier = Modifier.semantics { contentDescription = filterDescription }
+    ) {
+      Icon(imageVector = Icons.Default.FilterList, contentDescription = null)
+    }
+    // Dot in the selected level's color, matching the dropdown items' color coding, so the
+    // active level is glanceable without opening the menu.
+    Badge(
+      modifier = Modifier.align(Alignment.TopEnd),
+      containerColor = selectedLevel.toColor()
+    )
+    DropdownMenu(
+      expanded = isMenuExpanded,
+      onDismissRequest = { isMenuExpanded = false }
+    ) {
+      LogLevel.entries.forEach { level ->
+        val levelDescription = stringResource(R.string.debugoverlay_filter_chip_description, level.name)
+        DropdownMenuItem(
+          text = { Text(level.name) },
+          leadingIcon = {
+            Box(
+              modifier = Modifier
+                .size(10.dp)
+                .background(color = level.toColor(), shape = CircleShape)
+            )
+          },
+          trailingIcon = {
+            if (level == selectedLevel) {
+              Icon(imageVector = Icons.Default.Check, contentDescription = null)
+            }
+          },
+          modifier = Modifier.semantics {
+            role = Role.RadioButton
+            contentDescription = levelDescription
+            selected = level == selectedLevel
+          },
+          onClick = {
+            onLevelSelected(level)
+            isMenuExpanded = false
+          }
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun LogLevelFilters(
+  selectedLevel: LogLevel,
+  onLevelSelected: (LogLevel) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  FlowRow(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 8.dp, vertical = 4.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp)
+  ) {
+    LogLevel.entries.forEach { level ->
+      FilterChip(
+        label = level.name,
+        color = level.toColor(),
+        selected = selectedLevel == level,
+        onClick = { onLevelSelected(level) }
+      )
+    }
+  }
+}
+
+@Composable
+private fun FilterChip(
+  label: String,
+  color: Color,
+  selected: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val chipDescription = stringResource(R.string.debugoverlay_filter_chip_description, label)
+  Surface(
+    onClick = onClick,
+    modifier = modifier.semantics {
+      role = Role.RadioButton
+      contentDescription = chipDescription
+      this.selected = selected
+    },
+    shape = MaterialTheme.shapes.large,
+    color = if (selected) color.copy(alpha = 0.3f) else MaterialTheme.colorScheme.surfaceContainerHigh,
+    border = BorderStroke(
+      width = 1.dp,
+      color = if (selected) color else Color.Transparent
+    )
+  ) {
+    Text(
+      text = label,
+      modifier = Modifier.padding(6.dp),
+      style = MaterialTheme.typography.labelSmall,
+      color = if (selected) color else MaterialTheme.colorScheme.onSurface
+    )
+  }
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogFilterBar.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogFilterBar.kt
@@ -127,7 +127,10 @@ private fun LogLevelFilterMenu(
   modifier: Modifier = Modifier,
 ) {
   var isMenuExpanded by remember { mutableStateOf(false) }
-  val filterDescription = stringResource(R.string.debugoverlay_filter_logs_content_description)
+  val filterDescription = stringResource(
+    R.string.debugoverlay_filter_logs_content_description,
+    selectedLevel.name
+  )
 
   Box(modifier = modifier) {
     IconButton(

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/LogTabContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -30,12 +29,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -58,6 +55,7 @@ private data class LogFilterState(
   val onSearchQueryChanged: (String) -> Unit,
   val selectedLevel: LogLevel,
   val onLevelSelected: (LogLevel) -> Unit,
+  val isCompactHeight: Boolean,
 )
 
 /**
@@ -72,9 +70,15 @@ private data class LogFilterState(
  *
  * @param logsFlow Flow of log entries to collect and display.
  * @param modifier Modifier to be applied to the root layout
+ * @param isCompactHeight Whether the window has limited vertical space (e.g. landscape on a
+ *   small device), collapsing the filter bar to reclaim room for the log list.
  */
 @Composable
-internal fun LogTabContent(logsFlow: Flow<List<LogEntry>>, modifier: Modifier = Modifier) {
+internal fun LogTabContent(
+  logsFlow: Flow<List<LogEntry>>,
+  modifier: Modifier = Modifier,
+  isCompactHeight: Boolean = false,
+) {
   val logEntries by logsFlow.collectAsStateWithLifecycle(emptyList())
 
   var selectedLevel by remember { mutableStateOf(LogLevel.DEBUG) }
@@ -117,7 +121,8 @@ internal fun LogTabContent(logsFlow: Flow<List<LogEntry>>, modifier: Modifier = 
           searchQuery = searchQuery,
           onSearchQueryChanged = { searchQuery = it },
           selectedLevel = selectedLevel,
-          onLevelSelected = { selectedLevel = it }
+          onLevelSelected = { selectedLevel = it },
+          isCompactHeight = isCompactHeight
         ),
         filteredEntries = filteredEntries,
         listState = listState,
@@ -157,7 +162,8 @@ private fun LogListScreen(
         searchQuery = filterState.searchQuery,
         onSearchQueryChanged = filterState.onSearchQueryChanged,
         selectedLevel = filterState.selectedLevel,
-        onLevelSelected = filterState.onLevelSelected
+        onLevelSelected = filterState.onLevelSelected,
+        isCompactHeight = filterState.isCompactHeight
       )
 
       LogContent(
@@ -174,54 +180,6 @@ private fun LogListScreen(
         .align(Alignment.BottomEnd)
         .padding(16.dp)
     )
-  }
-}
-
-@Composable
-private fun LogFilterBar(
-  searchQuery: String,
-  onSearchQueryChanged: (String) -> Unit,
-  selectedLevel: LogLevel,
-  onLevelSelected: (LogLevel) -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  Column(modifier = modifier.fillMaxWidth().padding(top = 8.dp)) {
-    SearchField(
-      searchPlaceholder = stringResource(R.string.debugoverlay_search_logs),
-      searchQuery = searchQuery,
-      onSearchQueryChanged = onSearchQueryChanged,
-      modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 8.dp)
-    )
-
-    LogLevelFilters(
-      selectedLevel = selectedLevel,
-      onLevelSelected = onLevelSelected
-    )
-  }
-}
-
-@Composable
-private fun LogLevelFilters(
-  selectedLevel: LogLevel,
-  onLevelSelected: (LogLevel) -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  FlowRow(
-    modifier = modifier
-      .fillMaxWidth()
-      .padding(horizontal = 8.dp, vertical = 4.dp),
-    horizontalArrangement = Arrangement.spacedBy(8.dp)
-  ) {
-    LogLevel.entries.forEach { level ->
-      FilterChip(
-        label = level.name,
-        color = level.toColor(),
-        selected = selectedLevel == level,
-        onClick = { onLevelSelected(level) }
-      )
-    }
   }
 }
 
@@ -374,37 +332,5 @@ private fun LogEntryMetadata(entry: LogEntry, modifier: Modifier = Modifier) {
         overflow = TextOverflow.Ellipsis
       )
     }
-  }
-}
-
-@Composable
-private fun FilterChip(
-  label: String,
-  color: Color,
-  selected: Boolean,
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  val chipDescription = stringResource(R.string.debugoverlay_filter_chip_description, label)
-  Surface(
-    onClick = onClick,
-    modifier = modifier.semantics {
-      role = Role.RadioButton
-      contentDescription = chipDescription
-      this.selected = selected
-    },
-    shape = MaterialTheme.shapes.large,
-    color = if (selected) color.copy(alpha = 0.3f) else MaterialTheme.colorScheme.surfaceContainerHigh,
-    border = androidx.compose.foundation.BorderStroke(
-      width = 1.dp,
-      color = if (selected) color else Color.Transparent
-    )
-  ) {
-    Text(
-      text = label,
-      modifier = Modifier.padding(6.dp),
-      style = MaterialTheme.typography.labelSmall,
-      color = if (selected) color else MaterialTheme.colorScheme.onSurface
-    )
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkStatsHeader.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkStatsHeader.kt
@@ -1,0 +1,226 @@
+package com.ms.square.debugoverlay.internal.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.North
+import androidx.compose.material.icons.filled.South
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.ms.square.debugoverlay.core.R
+import com.ms.square.debugoverlay.internal.data.model.NetworkStats
+import com.ms.square.debugoverlay.internal.util.formatBytes
+
+/**
+ * Stats header showing download/upload totals, pinned above the request list (see
+ * [NetworkListScreen]) rather than scrolling with it — aggregate stats, especially the error
+ * count, are ambient signal worth keeping glanceable while scrolling requests, not a control
+ * the user reaches for and tucks away.
+ *
+ * On short-height windows ([isCompactHeight]), condenses to a single-line summary
+ * ([CompactNetworkStatsSummary]) instead of the full two-row card, to reclaim room for the
+ * request list while still keeping the (denser) stats pinned and visible.
+ */
+@Composable
+internal fun NetworkStatsHeader(networkStats: NetworkStats, isCompactHeight: Boolean, modifier: Modifier = Modifier) {
+  Surface(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp, vertical = if (isCompactHeight) 8.dp else 16.dp),
+    shape = MaterialTheme.shapes.medium,
+    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+    tonalElevation = 2.dp
+  ) {
+    if (isCompactHeight) {
+      CompactNetworkStatsSummary(
+        networkStats = networkStats,
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+      )
+    } else {
+      Column(
+        modifier = Modifier.padding(16.dp)
+      ) {
+        // Main stats row
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+          // Downloaded
+          NetworkStatsHeaderValue(
+            horizontalAlignment = Alignment.Start,
+            color = MaterialTheme.colorScheme.tertiary,
+            title = stringResource(R.string.debugoverlay_netstat_downloaded),
+            icon = Icons.Default.South,
+            value = formatBytes(networkStats.totalDownloaded)
+          )
+
+          // Uploaded
+          NetworkStatsHeaderValue(
+            horizontalAlignment = Alignment.End,
+            color = MaterialTheme.colorScheme.primary,
+            title = stringResource(R.string.debugoverlay_netstat_uploaded),
+            icon = Icons.Default.North,
+            value = formatBytes(networkStats.totalUploaded)
+          )
+        }
+        NetworkStatsHeaderSubRow(networkStats)
+      }
+    }
+  }
+}
+
+@Composable
+private fun NetworkStatsHeaderSubRow(networkStats: NetworkStats) {
+  if (!(networkStats.totalRequests == null || networkStats.errorCount == null || networkStats.avgDuration == null)) {
+    Spacer(modifier = Modifier.height(8.dp))
+
+    // Secondary stats row
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+      Text(
+        text = stringResource(R.string.debugoverlay_netstat_requests, networkStats.totalRequests),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+
+      if (networkStats.errorCount > 0) {
+        Text(
+          text = stringResource(R.string.debugoverlay_netstat_errors, networkStats.errorCount),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.error
+        )
+      }
+
+      Text(
+        text = stringResource(R.string.debugoverlay_netstat_avg_duration, networkStats.avgDuration),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}
+
+@Composable
+private fun NetworkStatsHeaderValue(
+  horizontalAlignment: Alignment.Horizontal,
+  color: Color,
+  title: String,
+  icon: ImageVector,
+  value: String,
+) {
+  Column(horizontalAlignment = horizontalAlignment) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+      Icon(
+        imageVector = icon,
+        contentDescription = null,
+        modifier = Modifier.size(20.dp),
+        tint = color
+      )
+      Text(
+        text = value,
+        style = MaterialTheme.typography.headlineSmall,
+        color = color,
+        fontWeight = FontWeight.Bold
+      )
+    }
+  }
+}
+
+/**
+ * Compact-height variant: every stat on one line (icon + value, no title captions, dot
+ * separators) so the pinned header costs a single row instead of a full card, while keeping
+ * download/upload/requests/errors/duration all still glanceable without scrolling.
+ * Wrapped in [FlowRow] as a defensive fallback for windows that are compact in both dimensions.
+ */
+@Composable
+private fun CompactNetworkStatsSummary(networkStats: NetworkStats, modifier: Modifier = Modifier) {
+  FlowRow(
+    modifier = modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalArrangement = Arrangement.spacedBy(2.dp)
+  ) {
+    CompactStatValue(
+      icon = Icons.Default.South,
+      color = MaterialTheme.colorScheme.tertiary,
+      value = formatBytes(networkStats.totalDownloaded)
+    )
+    Dot()
+    CompactStatValue(
+      icon = Icons.Default.North,
+      color = MaterialTheme.colorScheme.primary,
+      value = formatBytes(networkStats.totalUploaded)
+    )
+    if (!(networkStats.totalRequests == null || networkStats.errorCount == null || networkStats.avgDuration == null)) {
+      Dot()
+      Text(
+        text = stringResource(R.string.debugoverlay_netstat_requests, networkStats.totalRequests),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+      if (networkStats.errorCount > 0) {
+        Dot()
+        Text(
+          text = stringResource(R.string.debugoverlay_netstat_errors, networkStats.errorCount),
+          style = MaterialTheme.typography.bodySmall,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.error
+        )
+      }
+      Dot()
+      Text(
+        text = stringResource(R.string.debugoverlay_netstat_avg_duration, networkStats.avgDuration),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}
+
+@Composable
+private fun CompactStatValue(icon: ImageVector, color: Color, value: String, modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(2.dp)
+  ) {
+    Icon(
+      imageVector = icon,
+      contentDescription = null,
+      modifier = Modifier.size(14.dp),
+      tint = color
+    )
+    Text(
+      text = value,
+      style = MaterialTheme.typography.bodySmall,
+      color = color,
+      fontWeight = FontWeight.Bold
+    )
+  }
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkTabContent.kt
@@ -4,18 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.North
-import androidx.compose.material.icons.filled.South
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -26,11 +19,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -56,12 +46,16 @@ import kotlin.math.roundToInt
  * @param netStatsFlow Flow of network statistics to collect and display.
  * @param networkRequestsFlow Flow of network requests to collect and display.
  * @param modifier Modifier to be applied to the root layout.
+ * @param isCompactHeight Whether the window has limited vertical space (e.g. landscape on a
+ *   small device), condensing the stats header to a single-line summary to reclaim room for
+ *   the request list, while keeping it pinned — see [NetworkStatsHeader].
  */
 @Composable
 internal fun NetworkTabContent(
   netStatsFlow: Flow<NetworkStats>,
   networkRequestsFlow: Flow<List<NetworkRequest>>,
   modifier: Modifier = Modifier,
+  isCompactHeight: Boolean = false,
 ) {
   val networkStats by netStatsFlow.collectAsStateWithLifecycle(
     initialValue = NetworkStats.INITIAL_VALUE
@@ -99,7 +93,8 @@ internal fun NetworkTabContent(
         filteredRequests = filteredRequests,
         searchQuery = searchQuery,
         onSearchQueryChanged = { searchQuery = it },
-        onRequestClick = { selectedRequest = it }
+        onRequestClick = { selectedRequest = it },
+        isCompactHeight = isCompactHeight
       )
     },
     detailContent = { request ->
@@ -114,6 +109,11 @@ internal fun NetworkTabContent(
 
 /**
  * Network list screen with stats header and request list.
+ *
+ * The stats header stays pinned above the [LazyColumn] (not folded into scroll) since aggregate
+ * stats — especially the error count — are ambient signal worth keeping glanceable while
+ * scrolling the request list, not a control the user reaches for and tucks away. See
+ * [NetworkStatsHeader] for how it condenses on short-height windows instead.
  */
 @Composable
 private fun NetworkListScreen(
@@ -122,12 +122,13 @@ private fun NetworkListScreen(
   searchQuery: String,
   onSearchQueryChanged: (String) -> Unit,
   onRequestClick: (NetworkRequest) -> Unit,
+  isCompactHeight: Boolean,
   modifier: Modifier = Modifier,
 ) {
   Column(modifier = modifier.fillMaxSize()) {
     // Stats Header (only shown when supported)
     if (augmentedNetworkStats != NetworkStats.UNSUPPORTED) {
-      NetworkStatsHeader(augmentedNetworkStats)
+      NetworkStatsHeader(augmentedNetworkStats, isCompactHeight = isCompactHeight)
     }
 
     SearchField(
@@ -136,7 +137,6 @@ private fun NetworkListScreen(
       onSearchQueryChanged = onSearchQueryChanged
     )
 
-    // Request List (newest first)
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
@@ -151,118 +151,6 @@ private fun NetworkListScreen(
           onClick = { onRequestClick(request) }
         )
       }
-    }
-  }
-}
-
-/**
- * Stats header showing download/upload totals.
- */
-@Composable
-private fun NetworkStatsHeader(networkStats: NetworkStats, modifier: Modifier = Modifier) {
-  Surface(
-    modifier = modifier
-      .fillMaxWidth()
-      .padding(16.dp),
-    shape = MaterialTheme.shapes.medium,
-    color = MaterialTheme.colorScheme.surfaceContainerHighest,
-    tonalElevation = 2.dp
-  ) {
-    Column(
-      modifier = Modifier.padding(16.dp)
-    ) {
-      // Main stats row
-      Row(
-        modifier = modifier
-          .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-      ) {
-        // Downloaded
-        NetworkStatsHeaderValue(
-          horizontalAlignment = Alignment.Start,
-          color = MaterialTheme.colorScheme.tertiary,
-          title = stringResource(R.string.debugoverlay_netstat_downloaded),
-          icon = Icons.Default.South,
-          value = formatBytes(networkStats.totalDownloaded)
-        )
-
-        // Uploaded
-        NetworkStatsHeaderValue(
-          horizontalAlignment = Alignment.End,
-          color = MaterialTheme.colorScheme.primary,
-          title = stringResource(R.string.debugoverlay_netstat_uploaded),
-          icon = Icons.Default.North,
-          value = formatBytes(networkStats.totalUploaded)
-        )
-      }
-      NetworkStatsHeaderSubRow(networkStats)
-    }
-  }
-}
-
-@Composable
-private fun NetworkStatsHeaderSubRow(networkStats: NetworkStats) {
-  if (!(networkStats.totalRequests == null || networkStats.errorCount == null || networkStats.avgDuration == null)) {
-    Spacer(modifier = Modifier.height(8.dp))
-
-    // Secondary stats row
-    Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-      Text(
-        text = stringResource(R.string.debugoverlay_netstat_requests, networkStats.totalRequests),
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
-      )
-
-      if (networkStats.errorCount > 0) {
-        Text(
-          text = stringResource(R.string.debugoverlay_netstat_errors, networkStats.errorCount),
-          style = MaterialTheme.typography.bodyMedium,
-          color = MaterialTheme.colorScheme.error
-        )
-      }
-
-      Text(
-        text = stringResource(R.string.debugoverlay_netstat_avg_duration, networkStats.avgDuration),
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
-      )
-    }
-  }
-}
-
-@Composable
-private fun NetworkStatsHeaderValue(
-  horizontalAlignment: Alignment.Horizontal,
-  color: Color,
-  title: String,
-  icon: ImageVector,
-  value: String,
-) {
-  Column(horizontalAlignment = horizontalAlignment) {
-    Text(
-      text = title,
-      style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-      Icon(
-        imageVector = icon,
-        contentDescription = null,
-        modifier = Modifier.size(20.dp),
-        tint = color
-      )
-      Text(
-        text = value,
-        style = MaterialTheme.typography.headlineSmall,
-        color = color,
-        fontWeight = FontWeight.Bold
-      )
     }
   }
 }
@@ -379,7 +267,7 @@ private fun NetworkRequestMetadata(
 }
 
 @Composable
-private fun Dot() {
+internal fun Dot() {
   Text(
     text = "•",
     style = MaterialTheme.typography.bodySmall,

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
   <string name="debugoverlay_log_entry_description">Log entry: %1$s, %2$s</string>
   <string name="debugoverlay_filter_chip_description">Filter by %1$s level logs</string>
   <string name="debugoverlay_filter_tag">Filter Tag</string>
+  <string name="debugoverlay_filter_logs_content_description">Filter logs by level</string>
   <string name="debugoverlay_message_label">MESSAGE</string>
   <string name="debugoverlay_clipboard_label_log">Log Line</string>
 

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
   <string name="debugoverlay_log_entry_description">Log entry: %1$s, %2$s</string>
   <string name="debugoverlay_filter_chip_description">Filter by %1$s level logs</string>
   <string name="debugoverlay_filter_tag">Filter Tag</string>
-  <string name="debugoverlay_filter_logs_content_description">Filter logs by level</string>
+  <string name="debugoverlay_filter_logs_content_description">Filter logs by level, current: %1$s</string>
   <string name="debugoverlay_message_label">MESSAGE</string>
   <string name="debugoverlay_clipboard_label_log">Log Line</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3-windowsizeclass = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }


### PR DESCRIPTION
On short-height windows (e.g. landscape on a small/rugged handheld), the panel's TopAppBar + tab row + log tab's search field + filter-chip row left almost no room for the log list. When WindowHeightSizeClass is Compact (<480dp), the top bar now collapses on scroll and the log tab's filter bar merges into a single row with a level-filter dropdown instead of five chips; non-compact layouts are unchanged.


Claude-Session: https://claude.ai/code/session_015n6QTBkPf8MPbGKt3Nev5h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compact-height support to the debug panel, including height-aware scrolling for the top app bar.
  - Improved log filtering with a responsive filter bar (expanded chips vs compact dropdown) and enhanced selection indicators/semantics.
  - Updated the network tab to render a compact, pinned statistics header on short-height windows.
- **Bug Fixes**
  - Improved the log filter accessibility label to include the currently selected log level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->