### PR TITLE
feat: format JSON bodies and view full request/response in HTML reports

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import com.ms.square.debugoverlay.internal.bugreport.model.AppInfo
 import com.ms.square.debugoverlay.internal.bugreport.model.BugReportData
 import com.ms.square.debugoverlay.internal.bugreport.model.UserInput
+import com.ms.square.debugoverlay.internal.data.TextType
 import com.ms.square.debugoverlay.internal.data.model.AppExitInfo
 import com.ms.square.debugoverlay.internal.data.model.AppExitReason
 import com.ms.square.debugoverlay.internal.data.model.DeviceInfo
@@ -15,6 +16,7 @@ import com.ms.square.debugoverlay.internal.util.escapeHtml
 import com.ms.square.debugoverlay.internal.util.formatBytes
 import com.ms.square.debugoverlay.internal.util.formatBytesFromKb
 import com.ms.square.debugoverlay.internal.util.formatFullTimestamp
+import com.ms.square.debugoverlay.internal.util.formatJsonIfPossible
 import com.ms.square.debugoverlay.internal.util.formatTimestamp
 import com.ms.square.debugoverlay.model.LogEntry
 import com.ms.square.debugoverlay.model.NetworkRequest
@@ -98,7 +100,7 @@ internal object HtmlReportBuilder {
     append("    </div>")
   }
 
-  private fun buildHtmlString(data: BugReportData): String = buildString {
+  internal fun buildHtmlString(data: BugReportData): String = buildString {
     val timestamp = formatFullTimestamp(data.capturedAt)
 
     append("<!DOCTYPE html>\n")
@@ -636,10 +638,7 @@ internal object HtmlReportBuilder {
     }
     // Request body
     request.requestBody?.let { body ->
-      append("            <div class=\"detail-section\">\n")
-      append("              <div class=\"detail-label\">Request Body</div>\n")
-      append("              <div class=\"body-content\">${body.truncateBody().escapeHtml()}</div>\n")
-      append("            </div>\n")
+      appendBodySection("Request Body", body, request.requestHeaders.contentType())
     }
     // Response headers
     if (request.responseHeaders.isNotEmpty()) {
@@ -656,11 +655,39 @@ internal object HtmlReportBuilder {
     }
     // Response body
     request.responseBody?.let { body ->
-      append("            <div class=\"detail-section\">\n")
-      append("              <div class=\"detail-label\">Response Body</div>\n")
-      append("              <div class=\"body-content\">${body.truncateBody().escapeHtml()}</div>\n")
-      append("            </div>\n")
+      appendBodySection("Response Body", body, request.responseHeaders.contentType())
     }
+  }
+
+  private fun Map<String, String>.contentType(): String? =
+    entries.firstOrNull { it.key.equals("content-type", ignoreCase = true) }?.value
+
+  /**
+   * Renders a request/response body, pretty-printing it first if it is JSON.
+   * Bodies longer than [MAX_BODY_LENGTH] are truncated inline, with a "View Full" toggle
+   * (backed by a `data-full` attribute) that reveals the complete, untruncated content on click.
+   */
+  private fun StringBuilder.appendBodySection(label: String, rawBody: String, contentType: String?) {
+    val formatted = if (TextType.from(rawBody, contentType) == TextType.JSON) {
+      formatJsonIfPossible(rawBody)
+    } else {
+      rawBody
+    }
+    val isTruncated = formatted.length > MAX_BODY_LENGTH
+
+    append("            <div class=\"detail-section\">\n")
+    append("              <div class=\"detail-label\">${label.escapeHtml()}</div>\n")
+    append("              <div class=\"body-content\"")
+    if (isTruncated) {
+      append(" data-full=\"${formatted.escapeHtml()}\"")
+    }
+    append(">${formatted.truncateBody().escapeHtml()}</div>\n")
+    if (isTruncated) {
+      val fullSizeLabel = "View Full (${formatBytes(formatted.length.toLong())})"
+      append("              <div class=\"details-toggle\" data-label=\"${fullSizeLabel.escapeHtml()}\" ")
+      append("onclick=\"toggleFullBody(this)\">${fullSizeLabel.escapeHtml()}</div>\n")
+    }
+    append("            </div>\n")
   }
 
   private fun StringBuilder.appendJankStatsSection(jankStats: JankStatsUiState?) {
@@ -797,6 +824,21 @@ internal object HtmlReportBuilder {
     }
     function toggleNetworkDetails(toggle) {
       toggle.parentElement.classList.toggle('expanded');
+    }
+    function toggleFullBody(toggle) {
+      var content = toggle.previousElementSibling;
+      if (content.classList.contains('showing-full')) {
+        content.textContent = content.getAttribute('data-preview');
+        content.classList.remove('showing-full');
+        toggle.textContent = toggle.getAttribute('data-label');
+      } else {
+        if (!content.hasAttribute('data-preview')) {
+          content.setAttribute('data-preview', content.textContent);
+        }
+        content.textContent = content.getAttribute('data-full');
+        content.classList.add('showing-full');
+        toggle.textContent = 'Show Less';
+      }
     }
     function toggleExitTrace(toggle) {
       var trace = toggle.nextElementSibling;

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
@@ -665,12 +665,11 @@ internal object HtmlReportBuilder {
   /**
    * Renders a request/response body, pretty-printing it first if it is JSON.
    *
-   * Bodies longer than [MAX_BODY_LENGTH] are truncated inline, with a "View Full" toggle
-   * (backed by a `data-full` attribute) that reveals more content on click. The OkHttp extension
-   * can retain up to 100 requests with bodies up to 2MB each, so the expanded content is itself
-   * capped at [MAX_FULL_BODY_LENGTH] rather than embedding the true, unbounded body - otherwise a
-   * report with many large captured bodies could balloon the in-memory HTML string into the
-   * hundreds of megabytes and risk an OOM while generating the very report meant to help debug one.
+   * Bodies longer than [MAX_BODY_LENGTH] are truncated inline, with a toggle (backed by a
+   * `data-full` attribute) that reveals more content on click - genuinely the whole body only
+   * when it's at or under [MAX_FULL_BODY_LENGTH]; the label switches to "View More" and states
+   * the actual byte count otherwise, since embedding the true, unbounded body would defeat the
+   * point of capping it. See [MAX_FULL_BODY_LENGTH] for why the cap exists.
    */
   private fun StringBuilder.appendBodySection(label: String, rawBody: String, contentType: String?) {
     val formatted = if (TextType.from(rawBody, contentType) == TextType.JSON) {
@@ -688,7 +687,11 @@ internal object HtmlReportBuilder {
     }
     append(">${formatted.truncateBody().escapeHtml()}</div>\n")
     if (isTruncated) {
-      val toggleLabel = "View Full (${formatBytes(minOf(formatted.length, MAX_FULL_BODY_LENGTH).toLong())})"
+      val toggleLabel = if (formatted.length > MAX_FULL_BODY_LENGTH) {
+        "View More (first ${formatBytes(MAX_FULL_BODY_LENGTH.toLong())} of ${formatBytes(formatted.length.toLong())})"
+      } else {
+        "View Full (${formatBytes(formatted.length.toLong())})"
+      }
       append("              <div class=\"details-toggle\" data-label=\"${toggleLabel.escapeHtml()}\" ")
       append("onclick=\"toggleFullBody(this)\">${toggleLabel.escapeHtml()}</div>\n")
     }
@@ -872,7 +875,21 @@ internal object HtmlReportBuilder {
   private const val MAX_BODY_LENGTH = 2048
   private const val MAX_TRACE_LENGTH = 8192
 
-  // Caps how much of a body the "View Full" toggle embeds - see appendBodySection() KDoc.
+  /**
+   * Per-body cap on what the "View Full" / "View More" toggle embeds (see [appendBodySection]).
+   *
+   * The OkHttp extension's own defaults allow up to 100 stored requests with request/response
+   * bodies up to 2MB each - up to 200 bodies per report. Embedding every one in full, plus
+   * HTML-escaping overhead (quotes alone inflate typical JSON ~1.5-2x; a pathological all-quote
+   * body up to 6x), could add tens of megabytes to the in-memory report string in a realistic
+   * worst case - risking an OOM while generating the very report meant to help debug one.
+   *
+   * 64KB is not derived from that ceiling; it's a per-body limit chosen to feel clearly safer
+   * than [MAX_BODY_LENGTH] without being reckless, not a value computed by working backward from
+   * a target total. At this cap, 200 truncated bodies add roughly ~23MB in the realistic case,
+   * ~79MB in the pathological one - bounded, but a per-body cap, not a whole-report budget: it
+   * doesn't limit the aggregate as tightly as tracking a running total across the report would.
+   */
   private const val MAX_FULL_BODY_LENGTH = 64 * 1024
 
   // Placeholders for metadata injection - used by injectMetadata()

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
@@ -664,8 +664,13 @@ internal object HtmlReportBuilder {
 
   /**
    * Renders a request/response body, pretty-printing it first if it is JSON.
+   *
    * Bodies longer than [MAX_BODY_LENGTH] are truncated inline, with a "View Full" toggle
-   * (backed by a `data-full` attribute) that reveals the complete, untruncated content on click.
+   * (backed by a `data-full` attribute) that reveals more content on click. The OkHttp extension
+   * can retain up to 100 requests with bodies up to 2MB each, so the expanded content is itself
+   * capped at [MAX_FULL_BODY_LENGTH] rather than embedding the true, unbounded body - otherwise a
+   * report with many large captured bodies could balloon the in-memory HTML string into the
+   * hundreds of megabytes and risk an OOM while generating the very report meant to help debug one.
    */
   private fun StringBuilder.appendBodySection(label: String, rawBody: String, contentType: String?) {
     val formatted = if (TextType.from(rawBody, contentType) == TextType.JSON) {
@@ -679,13 +684,13 @@ internal object HtmlReportBuilder {
     append("              <div class=\"detail-label\">${label.escapeHtml()}</div>\n")
     append("              <div class=\"body-content\"")
     if (isTruncated) {
-      append(" data-full=\"${formatted.escapeHtml()}\"")
+      append(" data-full=\"${formatted.truncateBody(MAX_FULL_BODY_LENGTH).escapeHtml()}\"")
     }
     append(">${formatted.truncateBody().escapeHtml()}</div>\n")
     if (isTruncated) {
-      val fullSizeLabel = "View Full (${formatBytes(formatted.length.toLong())})"
-      append("              <div class=\"details-toggle\" data-label=\"${fullSizeLabel.escapeHtml()}\" ")
-      append("onclick=\"toggleFullBody(this)\">${fullSizeLabel.escapeHtml()}</div>\n")
+      val toggleLabel = "View Full (${formatBytes(minOf(formatted.length, MAX_FULL_BODY_LENGTH).toLong())})"
+      append("              <div class=\"details-toggle\" data-label=\"${toggleLabel.escapeHtml()}\" ")
+      append("onclick=\"toggleFullBody(this)\">${toggleLabel.escapeHtml()}</div>\n")
     }
     append("            </div>\n")
   }
@@ -866,6 +871,9 @@ internal object HtmlReportBuilder {
 
   private const val MAX_BODY_LENGTH = 2048
   private const val MAX_TRACE_LENGTH = 8192
+
+  // Caps how much of a body the "View Full" toggle embeds - see appendBodySection() KDoc.
+  private const val MAX_FULL_BODY_LENGTH = 64 * 1024
 
   // Placeholders for metadata injection - used by injectMetadata()
   private const val TITLE_PLACEHOLDER = "<!--TITLE_PLACEHOLDER-->"

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Texts.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/Texts.kt
@@ -28,21 +28,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.ms.square.debugoverlay.internal.data.TextType
 import com.ms.square.debugoverlay.internal.util.copyToClipboard
+import com.ms.square.debugoverlay.internal.util.formatJsonIfPossible
 import com.ms.square.debugoverlay.internal.util.formatTextSize
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 
 private const val COMPOSE_TEXT_MAX_SIZE = 10_000 // Use Compose Text
 private const val TEXT_VIEW_MAX_SIZE = 500_000 // Use TextView, above this truncate
-
-private val jsonFormatter = Json { prettyPrint = true }
-
-private fun formatJson(json: String): String = try {
-  val element = Json.parseToJsonElement(json)
-  jsonFormatter.encodeToString(JsonElement.serializer(), element)
-} catch (_: Exception) {
-  json
-}
 
 /**
  * Text preview with three-tier performance optimization for large texts.
@@ -52,7 +42,7 @@ internal fun TextPreview(text: String, textType: TextType) {
   // format if JSON
   val formatted = remember(text) {
     if (textType == TextType.JSON) {
-      formatJson(text)
+      formatJsonIfPossible(text)
     } else {
       text
     }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/JsonFormatting.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/JsonFormatting.kt
@@ -1,0 +1,16 @@
+package com.ms.square.debugoverlay.internal.util
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+private val prettyJson = Json { prettyPrint = true }
+
+/**
+ * Pretty-prints [text] if it parses as valid JSON, otherwise returns it unchanged.
+ */
+internal fun formatJsonIfPossible(text: String): String = try {
+  val element = Json.parseToJsonElement(text)
+  prettyJson.encodeToString(JsonElement.serializer(), element)
+} catch (_: Exception) {
+  text
+}

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
@@ -102,12 +102,13 @@ class HtmlReportBuilderTest {
 
     assertThat(html).contains("data-full=\"")
     assertThat(html).contains("View Full")
+    assertThat(html).doesNotContain("View More") // fits entirely within the cap, so it's genuinely "full"
     assertThat(html).contains("item-500") // well under the 64KB cap, so fully present in data-full
     assertThat(html).contains("truncated") // truncation notice still shown in the inline preview
   }
 
   @Test
-  fun `very large body caps the View Full content instead of embedding it unbounded`() {
+  fun `very large body caps the View Full content and labels it as partial`() {
     // ~200KB of raw content - comfortably exceeds the internal 64KB cap on the "View Full" payload,
     // guarding against a single report ballooning into hundreds of MB when many large bodies are captured.
     val hugeArray = (1..9999).joinToString(prefix = "[", postfix = "]") { "\"item-$it\"" }
@@ -117,5 +118,7 @@ class HtmlReportBuilderTest {
 
     assertThat(html).contains("item-1&quot;") // early content is well within the cap
     assertThat(html).doesNotContain("item-9999") // beyond the cap, so not embedded anywhere in the report
+    // Label must make clear this is a partial view, not the true "full" body.
+    assertThat(html).contains("View More (first 64.0 KB of")
   }
 }

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
@@ -94,7 +94,7 @@ class HtmlReportBuilderTest {
   }
 
   @Test
-  fun `large body renders a View Full toggle with complete untruncated content`() {
+  fun `large body renders a View Full toggle with expanded content`() {
     val largeArray = (1..500).joinToString(prefix = "[", postfix = "]") { "\"item-$it\"" }
     val html = buildHtml(
       listOf(networkRequest(responseBody = largeArray, responseHeaders = mapOf("Content-Type" to "application/json")))
@@ -102,7 +102,20 @@ class HtmlReportBuilderTest {
 
     assertThat(html).contains("data-full=\"")
     assertThat(html).contains("View Full")
-    assertThat(html).contains("item-500") // present in the full data attribute
+    assertThat(html).contains("item-500") // well under the 64KB cap, so fully present in data-full
     assertThat(html).contains("truncated") // truncation notice still shown in the inline preview
+  }
+
+  @Test
+  fun `very large body caps the View Full content instead of embedding it unbounded`() {
+    // ~200KB of raw content - comfortably exceeds the internal 64KB cap on the "View Full" payload,
+    // guarding against a single report ballooning into hundreds of MB when many large bodies are captured.
+    val hugeArray = (1..9999).joinToString(prefix = "[", postfix = "]") { "\"item-$it\"" }
+    val html = buildHtml(
+      listOf(networkRequest(responseBody = hugeArray, responseHeaders = mapOf("Content-Type" to "application/json")))
+    )
+
+    assertThat(html).contains("item-1&quot;") // early content is well within the cap
+    assertThat(html).doesNotContain("item-9999") // beyond the cap, so not embedded anywhere in the report
   }
 }

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilderTest.kt
@@ -1,0 +1,108 @@
+package com.ms.square.debugoverlay.internal.bugreport
+
+import com.google.common.truth.Truth.assertThat
+import com.ms.square.debugoverlay.internal.bugreport.model.AppInfo
+import com.ms.square.debugoverlay.internal.bugreport.model.BugReportData
+import com.ms.square.debugoverlay.model.NetworkRequest
+import org.junit.Test
+
+class HtmlReportBuilderTest {
+
+  private val appInfo = AppInfo(
+    packageName = "com.example.app",
+    versionName = "1.0.0",
+    versionCode = 1,
+    targetSdkVersion = 34,
+    minSdkVersion = 24,
+    isDebuggable = true,
+    installerStore = "Unknown",
+    installerPackage = null,
+    firstInstallTime = 0L,
+    lastUpdateTime = 0L
+  )
+
+  private fun reportData(networkRequests: List<NetworkRequest>) = BugReportData(
+    capturedAt = 1706400000000L,
+    userInput = null,
+    appInfo = appInfo,
+    screenshot = null,
+    deviceInfo = null,
+    logcatLogs = emptyList(),
+    customLogSourceData = null,
+    networkRequests = networkRequests,
+    jankStats = null,
+    appExitInfos = emptyList(),
+    uiHierarchy = null
+  )
+
+  private fun networkRequest(responseBody: String?, responseHeaders: Map<String, String> = emptyMap()) = NetworkRequest(
+    protocol = "h2",
+    method = "GET",
+    url = "https://example.com/api",
+    statusCode = 200,
+    durationMs = 42,
+    responseSize = responseBody?.length?.toLong(),
+    requestSize = 0,
+    responseHeaders = responseHeaders,
+    responseBody = responseBody
+  )
+
+  private fun buildHtml(networkRequests: List<NetworkRequest>): String =
+    HtmlReportBuilder.buildHtmlString(reportData(networkRequests))
+
+  @Test
+  fun `pretty-prints JSON response body detected via Content-Type header`() {
+    val html = buildHtml(
+      listOf(
+        networkRequest(
+          responseBody = """{"name":"test","count":2}""",
+          responseHeaders = mapOf("Content-Type" to "application/json")
+        )
+      )
+    )
+
+    // Pretty-printed JSON is indented onto multiple lines; the compact form is not present.
+    assertThat(html).contains("&quot;name&quot;: &quot;test&quot;")
+    assertThat(html).doesNotContain("""{"name":"test","count":2}""")
+  }
+
+  @Test
+  fun `pretty-prints JSON response body detected via content sniffing when header missing`() {
+    val html = buildHtml(listOf(networkRequest(responseBody = """{"ok":true}""")))
+
+    assertThat(html).contains("&quot;ok&quot;: true")
+  }
+
+  @Test
+  fun `leaves non-JSON response body unformatted`() {
+    val body = "plain text response body"
+    val html = buildHtml(
+      listOf(networkRequest(responseBody = body, responseHeaders = mapOf("Content-Type" to "text/plain")))
+    )
+
+    assertThat(html).contains(body)
+    assertThat(html).doesNotContain("View Full")
+    assertThat(html).doesNotContain("data-full=")
+  }
+
+  @Test
+  fun `small body does not render a View Full toggle`() {
+    val html = buildHtml(listOf(networkRequest(responseBody = """{"ok":true}""")))
+
+    assertThat(html).doesNotContain("data-full=")
+    assertThat(html).doesNotContain("onclick=\"toggleFullBody(this)\"")
+  }
+
+  @Test
+  fun `large body renders a View Full toggle with complete untruncated content`() {
+    val largeArray = (1..500).joinToString(prefix = "[", postfix = "]") { "\"item-$it\"" }
+    val html = buildHtml(
+      listOf(networkRequest(responseBody = largeArray, responseHeaders = mapOf("Content-Type" to "application/json")))
+    )
+
+    assertThat(html).contains("data-full=\"")
+    assertThat(html).contains("View Full")
+    assertThat(html).contains("item-500") // present in the full data attribute
+    assertThat(html).contains("truncated") // truncation notice still shown in the inline preview
+  }
+}

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/JsonFormattingTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/JsonFormattingTest.kt
@@ -1,0 +1,42 @@
+package com.ms.square.debugoverlay.internal.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class JsonFormattingTest {
+
+  @Test
+  fun `formatJsonIfPossible pretty-prints compact JSON object`() {
+    val input = """{"name":"test","count":2}"""
+
+    val result = formatJsonIfPossible(input)
+
+    assertThat(result).isEqualTo(
+      """
+      {
+          "name": "test",
+          "count": 2
+      }
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `formatJsonIfPossible returns input unchanged when not valid JSON`() {
+    val input = "plain text response, not json at all"
+
+    assertThat(formatJsonIfPossible(input)).isEqualTo(input)
+  }
+
+  @Test
+  fun `formatJsonIfPossible returns input unchanged for malformed JSON`() {
+    val input = """{"name":"test", "unterminated"""
+
+    assertThat(formatJsonIfPossible(input)).isEqualTo(input)
+  }
+
+  @Test
+  fun `formatJsonIfPossible returns empty string unchanged`() {
+    assertThat(formatJsonIfPossible("")).isEqualTo("")
+  }
+}


### PR DESCRIPTION
## Summary
* Request/response bodies in the HTML bug report are pretty-printed when detected as JSON (Content-Type header or content sniffing).
* Truncated bodies (>2KB) get a toggle to view more: "View Full" if the body fits within a 64KB cap, "View More (first 64.0 KB of Y)" otherwise — capped per-body to bound report memory (OkHttp extension allows up to 100 requests × 2MB bodies).
* Extracted JSON pretty-printing into shared `internal/util/JsonFormatting.kt`, reused by the live overlay panel and the report builder.

Resolves #258. Filed #261 as a follow-up for pre-existing (not introduced here) keyboard-accessibility gaps across all report toggles.

## Test plan
- [x] `./gradlew :debugoverlay-core:check` passes
- [x] `./gradlew :sample:assembleDebug` builds
- [x] `JsonFormattingTest`, `HtmlReportBuilderTest` cover formatting, truncation, and the memory cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n6QTBkPf8MPbGKt3Nev5h