### PR TITLE
docs: update README for v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Version 2.6.2 *(2026-07-21)*
+
+### New Features
+
+* **Formatted JSON bodies and full request/response view in HTML reports** – Request/response bodies in the HTML bug report are now pretty-printed when detected as JSON (via Content-Type header or content sniffing). Truncated bodies (>2KB) get a toggle to view more: "View Full" if the body fits within a 64KB cap, or "View More (first 64.0 KB of Y)" otherwise, capped per-body to bound report memory. Resolves [#258](https://github.com/Manabu-GT/DebugOverlay-Android/issues/258).
+
+### Bug Fixes
+
+* **Debug Panel filter bar now collapses on short-height windows** – The panel gains compact-height support, including height-aware scrolling for the top app bar. Log filtering switches to a responsive filter bar (expanded chips vs. compact dropdown) with improved selection indicators/semantics, and the Network tab renders a compact, pinned statistics header on short-height windows. Resolves [#257](https://github.com/Manabu-GT/DebugOverlay-Android/issues/257).
+
 ## Version 2.6.1 *(2026-05-21)*
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.6.1")
+debugImplementation("com.ms-square:debugoverlay:2.6.2")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -73,7 +73,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.6.1"
+debugoverlay = "2.6.2"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -99,7 +99,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay:2.6.2")
 }
 ```
 
@@ -154,8 +154,8 @@ For a zero-config shake trigger, add the shake extension:
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.1")
-  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.2")
 }
 ```
 
@@ -207,8 +207,8 @@ The value also bounds the `logcat -T N` / `-t N` calls, so it caps how many line
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.1")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.2")
 }
 ```
 
@@ -239,8 +239,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.1")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.1")
+  debugImplementation("com.ms-square:debugoverlay:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.2")
 }
 ```
 
@@ -364,7 +364,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.1")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.2")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Bump dependency coordinate examples in README from `2.6.1` to `2.6.2`.
- Add CHANGELOG entry for v2.6.2 covering formatted JSON bodies / full request-response view in HTML reports (#258) and the Debug Panel short-height filter bar fix (#257).

## Test plan
- [x] Docs-only change; no build/test required per `docs/TESTING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZnfM8nacaiBarhGKuCjuG