### PR TITLE
refactor: Modifier.draggableOverlay as a Modifier.Node

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/BugReporterFab.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/BugReporterFab.kt
@@ -64,6 +64,7 @@ internal fun BugReporterFab(
   modifier: Modifier = Modifier,
   bugReportGenerator: BugReportGenerator = DebugOverlay.bugReportGenerator,
   onError: (String) -> Unit = {},
+  clickEnabled: () -> Boolean = { true },
 ) {
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
@@ -98,7 +99,7 @@ internal fun BugReporterFab(
   Box(modifier = modifier) {
     FloatingActionButton(
       onClick = {
-        if (fabState == BugReporterFabState.Idle) {
+        if (clickEnabled() && fabState == BugReporterFabState.Idle) {
           if (draftCount > 0) {
             BugReportActivity.launchWithDraftPicker(context)
           } else {

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraggableBugReporterFab.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraggableBugReporterFab.kt
@@ -79,7 +79,7 @@ internal fun DraggableBugReporterFab(
     //   └─ Inner Box [padding reserves space for 1.1x scale]
     //        └─ BugReporterFab [56dp, scales to ~62dp during drag]
     Box(modifier = Modifier.padding(FAB_DRAG_PADDING)) {
-      BugReporterFab(onError = onError)
+      BugReporterFab(onError = onError, clickEnabled = { !state.isDragging })
     }
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraggableBugReporterFab.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraggableBugReporterFab.kt
@@ -1,25 +1,17 @@
 package com.ms.square.debugoverlay.internal.bugreport.ui
 
-import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.ms.square.debugoverlay.internal.ui.DragVisualFeedback
 import com.ms.square.debugoverlay.internal.ui.draggableOverlay
 import com.ms.square.debugoverlay.internal.ui.rememberDraggableOverlayState
 import kotlin.math.roundToInt
@@ -49,50 +41,41 @@ internal fun DraggableBugReporterFab(
   onPositionChanged: (x: Int, y: Int) -> Unit,
   onError: (String) -> Unit = {},
 ) {
-  val windowInfo = LocalWindowInfo.current
-  val view = LocalView.current
-  val scope = rememberCoroutineScope()
   val currentOnPositionChanged by rememberUpdatedState(onPositionChanged)
 
-  var contentSize by remember { mutableStateOf(IntSize.Zero) }
-  val screenSize = remember(windowInfo.containerSize) {
-    IntSize(windowInfo.containerSize.width, windowInfo.containerSize.height)
-  }
-
   val state = rememberDraggableOverlayState(
-    initialOffsetX = initialOffsetX,
-    initialOffsetY = initialOffsetY
+    initialOffset = Offset(initialOffsetX, initialOffsetY)
   )
 
-  // Clamp position when screen size changes (e.g., rotation)
-  LaunchedEffect(screenSize, contentSize) {
-    state.clampToBounds(contentSize, screenSize)
-  }
-
-  // Report position changes for WindowManager updates
+  // Report position changes for WindowManager updates.
+  // Rounding inside snapshotFlow means only whole-pixel changes are emitted — snapshotFlow drops
+  // emissions equal to the previous one, so this avoids a WindowManager call per animation frame.
   LaunchedEffect(Unit) {
-    snapshotFlow { state.offsetX.value to state.offsetY.value }
-      .collect { (x, y) -> currentOnPositionChanged(x.roundToInt(), y.roundToInt()) }
+    snapshotFlow {
+      IntOffset(state.offset.value.x.roundToInt(), state.offset.value.y.roundToInt())
+    }.collect { position -> currentOnPositionChanged(position.x, position.y) }
   }
 
   Box(
-    modifier = modifier
-      .onSizeChanged { contentSize = it }
-      .draggableOverlay(
-        state = state,
-        screenSize = screenSize,
-        contentSize = contentSize,
-        scope = scope,
-        visualFeedback = DragVisualFeedback(draggingAlpha = 0.7f, draggingScale = 1.1f),
-        onHapticFeedback = { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
-      ),
+    modifier = modifier.draggableOverlay(
+      state = state,
+      draggingScale = 1.1f
+    ),
     contentAlignment = Alignment.Center
   ) {
     // Inner Box with padding to prevent clipping during drag scale (1.1x).
-    // This padding MUST be inside the outer Box so onSizeChanged() captures
-    // the total size including padding, reserving layout space for the scaled FAB.
+    //
+    // draggingScale is a graphicsLayer transform, so it is draw-only and leaves the measured size
+    // unchanged. This overlay's window is WRAP_CONTENT, so its surface is sized to that measured
+    // size, and the compositor clips anything drawn beyond the surface. That clip is outside
+    // Compose's control: graphicsLayer's clip = false does not affect it, and neither does
+    // clipChildren (AndroidComposeView already sets it to false on itself). The only fix is real
+    // layout space — verified on device, the FAB visibly clips without this.
+    //
+    // The padding MUST be inside the outer Box so the size draggableOverlay observes via
+    // onRemeasured() includes it.
     // Layout structure:
-    // Outer Box [onSizeChanged captures total size including padding]
+    // Outer Box [draggableOverlay observes total size including padding]
     //   └─ Inner Box [padding reserves space for 1.1x scale]
     //        └─ BugReporterFab [56dp, scales to ~62dp during drag]
     Box(modifier = Modifier.padding(FAB_DRAG_PADDING)) {

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
@@ -63,7 +63,6 @@ internal fun DraggableOverlayPanel(
 ) {
   val currentOnPositionChanged by rememberUpdatedState(onPositionChanged)
   val currentOnClick by rememberUpdatedState(onClick)
-  val panelDescription = stringResource(R.string.debugoverlay_panel_content_description)
 
   val state = rememberDraggableOverlayState(
     initialOffset = Offset(initialOffsetX, initialOffsetY)
@@ -85,13 +84,17 @@ internal fun DraggableOverlayPanel(
       .clickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = null,
-        onClickLabel = stringResource(R.string.debugoverlay_panel_open_action_label)
+        onClickLabel = stringResource(R.string.debugoverlay_panel_open_action_label),
+        role = Role.Button
       ) {
         if (!state.isDragging) {
           currentOnClick()
         }
       }
-      .semantics { contentDescription = panelDescription }
+      // Merge so TalkBack stops once on the panel rather than on every metric row. Deliberately no
+      // contentDescription: on a merging node it would replace the children's text, and those
+      // children are the metric values worth reading out.
+      .semantics(mergeDescendants = true) {}
   ) {
     DebugOverlayPanel(
       metrics = metrics,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -2,10 +2,8 @@
 
 package com.ms.square.debugoverlay.internal.ui
 
-import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,36 +20,31 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.model.DebugOverlayPanelMetrics
 import com.ms.square.debugoverlay.internal.data.model.Metrics
 import com.ms.square.debugoverlay.internal.data.model.ThermalState
 import com.ms.square.debugoverlay.internal.data.model.ThermalStatus
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.roundToInt
 
 private val STATUS_COLOR_NORMAL = Color(0xFF4CAF50)
 private val STATUS_COLOR_WARNING = Color(0xFFFF9800)
 private val STATUS_COLOR_CRITICAL = Color(0xFFF44336)
+
+// Padding to accommodate scale effect during drag
+private val PANEL_DRAG_PADDING = 8.dp
 
 @Composable
 internal fun DraggableOverlayPanel(
@@ -63,54 +56,20 @@ internal fun DraggableOverlayPanel(
   onPositionChanged: (x: Int, y: Int) -> Unit,
   onClick: () -> Unit,
 ) {
-  val windowInfo = LocalWindowInfo.current
-  val view = LocalView.current
-  val scope = rememberCoroutineScope()
   val currentOnPositionChanged by rememberUpdatedState(onPositionChanged)
-  val currentOnClick by rememberUpdatedState(onClick)
-
-  var panelSize by remember { mutableStateOf(IntSize.Zero) }
-  val screenSize = remember(windowInfo.containerSize) {
-    IntSize(windowInfo.containerSize.width, windowInfo.containerSize.height)
-  }
 
   val state = rememberDraggableOverlayState(
-    initialOffsetX = initialOffsetX,
-    initialOffsetY = initialOffsetY
+    initialOffset = Offset(initialOffsetX, initialOffsetY)
   )
-
-  // Clamp position when screen size changes (e.g., rotation)
-  LaunchedEffect(screenSize, panelSize) {
-    state.clampToBounds(panelSize, screenSize)
-  }
 
   // Report position changes for WindowManager updates
   LaunchedEffect(Unit) {
-    snapshotFlow { state.offsetX.value.roundToInt() to state.offsetY.value.roundToInt() }
-      .distinctUntilChanged()
-      .collect { (x, y) -> currentOnPositionChanged(x, y) }
+    snapshotFlow { IntOffset(state.offset.value.x.roundToInt(), state.offset.value.y.roundToInt()) }
+      .collect { offset -> currentOnPositionChanged(offset.x, offset.y) }
   }
 
   Box(
-    modifier = modifier
-      .onSizeChanged { panelSize = it }
-      .draggableOverlay(
-        state = state,
-        screenSize = screenSize,
-        contentSize = panelSize,
-        scope = scope,
-        onHapticFeedback = { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
-      )
-      .pointerInput(Unit) {
-        // Tap detection (separate from drag)
-        detectTapGestures(
-          onTap = {
-            if (!state.isDragging) {
-              currentOnClick()
-            }
-          }
-        )
-      }
+    modifier = modifier.draggableOverlay(state = state, onClick = onClick)
   ) {
     DebugOverlayPanel(
       metrics = metrics,
@@ -136,7 +95,7 @@ internal fun DebugOverlayPanel(
     metrics?.let {
       Surface(
         modifier = modifier
-          .padding(all = 8.dp)
+          .padding(all = PANEL_DRAG_PADDING)
           .border(
             width = 1.dp,
             color = MaterialTheme.colorScheme.outline.copy(alpha = 0.12f),

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -4,6 +4,8 @@ package com.ms.square.debugoverlay.internal.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -28,6 +31,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -57,6 +62,8 @@ internal fun DraggableOverlayPanel(
   onClick: () -> Unit,
 ) {
   val currentOnPositionChanged by rememberUpdatedState(onPositionChanged)
+  val currentOnClick by rememberUpdatedState(onClick)
+  val panelDescription = stringResource(R.string.debugoverlay_panel_content_description)
 
   val state = rememberDraggableOverlayState(
     initialOffset = Offset(initialOffsetX, initialOffsetY)
@@ -69,7 +76,22 @@ internal fun DraggableOverlayPanel(
   }
 
   Box(
-    modifier = modifier.draggableOverlay(state = state, onClick = onClick)
+    modifier = modifier
+      .draggableOverlay(state = state)
+      // clickable rather than a raw detectTapGestures so TalkBack's double-tap — which dispatches
+      // ACTION_CLICK, never pointer events — can open the panel. indication = null keeps the ripple
+      // off. Like detectTapGestures it has no long-press timeout, so a long-press that never moved
+      // would also register as a click, hence the isDragging guard.
+      .clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+        onClickLabel = stringResource(R.string.debugoverlay_panel_open_action_label)
+      ) {
+        if (!state.isDragging) {
+          currentOnClick()
+        }
+      }
+      .semantics { contentDescription = panelDescription }
   ) {
     DebugOverlayPanel(
       metrics = metrics,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
@@ -26,8 +26,10 @@ import kotlinx.coroutines.launch
  * the END/TOP coordinate convention live in [DraggableOverlayState].
  *
  * Tap handling is deliberately NOT included: compose it at the call site with a chained
- * `pointerInput { detectTapGestures { … } }`, guarded on [DraggableOverlayState.isDragging] so a
- * long-press that never moves does not also register as a tap.
+ * `clickable(indication = null)` — not a raw `detectTapGestures`, which never receives the
+ * `ACTION_CLICK` that TalkBack's double-tap dispatches. Guard it on
+ * [DraggableOverlayState.isDragging]: neither has a long-press timeout, so a long-press that never
+ * moves would otherwise also register as a click.
  *
  * [draggingScale] is draw-only and does not enlarge the measured size, so a caller in a WRAP_CONTENT
  * window must reserve layout room for it itself (see `FAB_DRAG_PADDING`, `PANEL_DRAG_PADDING`) or the
@@ -110,7 +112,9 @@ private class DraggableOverlayNode(
         coroutineScope.launch { state.settle() }
       },
       onDragCancel = {
+        // Settle here too, or a canceled gesture strands the overlay mid-screen.
         state.onDragStopped()
+        coroutineScope.launch { state.settle() }
       }
     )
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
@@ -1,7 +1,6 @@
 package com.ms.square.debugoverlay.internal.ui
 
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -18,32 +17,33 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntSize
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 /**
- * Makes a composable draggable via long-press, with snap-to-edge and tap handling.
+ * Makes a composable draggable via long-press, with snap-to-edge behavior.
  *
  * Owns only the platform plumbing — gestures, haptics, sizes, the visual layer. The motion model and
  * the END/TOP coordinate convention live in [DraggableOverlayState].
  *
+ * Tap handling is deliberately NOT included: compose it at the call site with a chained
+ * `pointerInput { detectTapGestures { … } }`, guarded on [DraggableOverlayState.isDragging] so a
+ * long-press that never moves does not also register as a tap.
+ *
  * [draggingScale] is draw-only and does not enlarge the measured size, so a caller in a WRAP_CONTENT
- * window must reserve layout room for it itself (see `FAB_DRAG_PADDING`) or the window surface clips
- * the scaled draw — a clip outside Compose's control. Left to the caller because it is specific to
- * that host.
+ * window must reserve layout room for it itself (see `FAB_DRAG_PADDING`, `PANEL_DRAG_PADDING`) or the
+ * window surface clips the scaled draw — a clip outside Compose's control. Left to the caller because
+ * it is specific to that host.
  *
  * @param state The draggable state holder
  * @param draggingAlpha Opacity applied while dragging
  * @param draggingScale Scale applied while dragging
  * @param hapticFeedbackEnabled Whether to buzz on drag start
- * @param onClick Invoked on tap. Null disables tap detection entirely.
  */
 internal fun Modifier.draggableOverlay(
   state: DraggableOverlayState,
   draggingAlpha: Float = 0.7f,
   draggingScale: Float = 1.05f,
   hapticFeedbackEnabled: Boolean = true,
-  onClick: (() -> Unit)? = null,
 ): Modifier = this
   // One layer, and isDragging is read in the layer block rather than at composition time, so drag
   // start/end updates layer params only — no recomposition.
@@ -54,24 +54,20 @@ internal fun Modifier.draggableOverlay(
     scaleX = targetScale
     scaleY = targetScale
   }
-  .then(DraggableOverlayElement(state, hapticFeedbackEnabled, onClick))
+  .then(DraggableOverlayElement(state, hapticFeedbackEnabled))
 
-private data class DraggableOverlayElement(
-  val state: DraggableOverlayState,
-  val hapticFeedbackEnabled: Boolean,
-  val onClick: (() -> Unit)?,
-) : ModifierNodeElement<DraggableOverlayNode>() {
+private data class DraggableOverlayElement(val state: DraggableOverlayState, val hapticFeedbackEnabled: Boolean) :
+  ModifierNodeElement<DraggableOverlayNode>() {
 
-  override fun create(): DraggableOverlayNode = DraggableOverlayNode(state, hapticFeedbackEnabled, onClick)
+  override fun create(): DraggableOverlayNode = DraggableOverlayNode(state, hapticFeedbackEnabled)
 
   override fun update(node: DraggableOverlayNode) {
-    node.update(state, hapticFeedbackEnabled, onClick)
+    node.update(state, hapticFeedbackEnabled)
   }
 
   override fun InspectorInfo.inspectableProperties() {
     name = "draggableOverlay"
     properties["hapticFeedbackEnabled"] = hapticFeedbackEnabled
-    properties["onClick"] = onClick
     properties["state"] = state
   }
 }
@@ -79,7 +75,6 @@ private data class DraggableOverlayElement(
 private class DraggableOverlayNode(
   private var state: DraggableOverlayState,
   private var hapticFeedbackEnabled: Boolean,
-  private var onClick: (() -> Unit)?,
 ) : DelegatingNode(),
   LayoutAwareModifierNode,
   CompositionLocalConsumerModifierNode,
@@ -88,30 +83,8 @@ private class DraggableOverlayNode(
   private var contentSize = IntSize.Zero
   private var containerSize = IntSize.Zero
 
-  private val pointerInputNode = delegate(SuspendingPointerInputModifierNode { detectGestures() })
-
-  /**
-   * Both detectors run in parallel on the same events, arbitrating by consumption: once the long
-   * press fires the drag consumes every MOVE, which makes the tap detector's `waitForUpOrCancellation`
-   * return null, so it skips `onTap` and waits for the next gesture. Neither detector ever returns —
-   * both loop until this handler is reset.
-   */
-  private suspend fun PointerInputScope.detectGestures() {
-    coroutineScope {
-      launch { detectDrags() }
-      // Skipped entirely when there is no onClick, so callers like the FAB — whose content has its
-      // own clickable — do not get a down-consumer they have no use for.
-      if (onClick != null) launch { detectTaps() }
-    }
-  }
-
-  /**
-   * [detectTapGestures] with no `onLongPress` applies no long-press timeout: it fires on release
-   * regardless of hold duration. So a long-press that never moves would otherwise register as a tap,
-   * which is what the [DraggableOverlayState.isDragging] guard rules out.
-   */
-  private suspend fun PointerInputScope.detectTaps() {
-    detectTapGestures(onTap = { if (!state.isDragging) onClick?.invoke() })
+  init {
+    delegate(SuspendingPointerInputModifierNode { detectDrags() })
   }
 
   private suspend fun PointerInputScope.detectDrags() {
@@ -172,16 +145,8 @@ private class DraggableOverlayNode(
     state.updateBounds(contentSize, containerSize)
   }
 
-  fun update(state: DraggableOverlayState, hapticFeedbackEnabled: Boolean, onClick: (() -> Unit)?) {
+  fun update(state: DraggableOverlayState, hapticFeedbackEnabled: Boolean) {
     this.hapticFeedbackEnabled = hapticFeedbackEnabled
-
-    // Only the null-ness matters to the handler; the lambda itself is read fresh on every tap, so it
-    // can never go stale and a mere identity change needs no restart.
-    val tapDetectionChanged = (this.onClick == null) != (onClick == null)
-    this.onClick = onClick
-    if (tapDetectionChanged) {
-      pointerInputNode.resetPointerInputHandler()
-    }
 
     if (this.state !== state) {
       this.state = state

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayModifier.kt
@@ -1,64 +1,191 @@
 package com.ms.square.debugoverlay.internal.ui
 
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntSize
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 /**
- * Visual feedback configuration during drag.
- */
-internal data class DragVisualFeedback(val draggingAlpha: Float = 0.7f, val draggingScale: Float = 1.05f)
-
-/**
- * Makes a composable draggable via long-press with position persistence and snap-to-edge behavior.
+ * Makes a composable draggable via long-press, with snap-to-edge and tap handling.
+ *
+ * Owns only the platform plumbing — gestures, haptics, sizes, the visual layer. The motion model and
+ * the END/TOP coordinate convention live in [DraggableOverlayState].
+ *
+ * [draggingScale] is draw-only and does not enlarge the measured size, so a caller in a WRAP_CONTENT
+ * window must reserve layout room for it itself (see `FAB_DRAG_PADDING`) or the window surface clips
+ * the scaled draw — a clip outside Compose's control. Left to the caller because it is specific to
+ * that host.
  *
  * @param state The draggable state holder
- * @param screenSize Current screen size for bounds calculation
- * @param contentSize Size of the draggable content
- * @param scope CoroutineScope for launching animations
- * @param visualFeedback Alpha/scale effects during drag
- * @param onHapticFeedback Callback to trigger haptic feedback on drag start
+ * @param draggingAlpha Opacity applied while dragging
+ * @param draggingScale Scale applied while dragging
+ * @param hapticFeedbackEnabled Whether to buzz on drag start
+ * @param onClick Invoked on tap. Null disables tap detection entirely.
  */
 internal fun Modifier.draggableOverlay(
   state: DraggableOverlayState,
-  screenSize: IntSize,
-  contentSize: IntSize,
-  scope: CoroutineScope,
-  visualFeedback: DragVisualFeedback = DragVisualFeedback(),
-  onHapticFeedback: () -> Unit = {},
+  draggingAlpha: Float = 0.7f,
+  draggingScale: Float = 1.05f,
+  hapticFeedbackEnabled: Boolean = true,
+  onClick: (() -> Unit)? = null,
 ): Modifier = this
-  .alpha(if (state.isDragging) visualFeedback.draggingAlpha else 1f)
-  .scale(if (state.isDragging) visualFeedback.draggingScale else 1f)
-  .pointerInput(screenSize, contentSize) {
+  // One layer, and isDragging is read in the layer block rather than at composition time, so drag
+  // start/end updates layer params only — no recomposition.
+  .graphicsLayer {
+    val dragging = state.isDragging
+    alpha = if (dragging) draggingAlpha else 1f
+    val targetScale = if (dragging) draggingScale else 1f
+    scaleX = targetScale
+    scaleY = targetScale
+  }
+  .then(DraggableOverlayElement(state, hapticFeedbackEnabled, onClick))
+
+private data class DraggableOverlayElement(
+  val state: DraggableOverlayState,
+  val hapticFeedbackEnabled: Boolean,
+  val onClick: (() -> Unit)?,
+) : ModifierNodeElement<DraggableOverlayNode>() {
+
+  override fun create(): DraggableOverlayNode = DraggableOverlayNode(state, hapticFeedbackEnabled, onClick)
+
+  override fun update(node: DraggableOverlayNode) {
+    node.update(state, hapticFeedbackEnabled, onClick)
+  }
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "draggableOverlay"
+    properties["hapticFeedbackEnabled"] = hapticFeedbackEnabled
+    properties["onClick"] = onClick
+    properties["state"] = state
+  }
+}
+
+private class DraggableOverlayNode(
+  private var state: DraggableOverlayState,
+  private var hapticFeedbackEnabled: Boolean,
+  private var onClick: (() -> Unit)?,
+) : DelegatingNode(),
+  LayoutAwareModifierNode,
+  CompositionLocalConsumerModifierNode,
+  ObserverModifierNode {
+
+  private var contentSize = IntSize.Zero
+  private var containerSize = IntSize.Zero
+
+  private val pointerInputNode = delegate(SuspendingPointerInputModifierNode { detectGestures() })
+
+  /**
+   * Both detectors run in parallel on the same events, arbitrating by consumption: once the long
+   * press fires the drag consumes every MOVE, which makes the tap detector's `waitForUpOrCancellation`
+   * return null, so it skips `onTap` and waits for the next gesture. Neither detector ever returns —
+   * both loop until this handler is reset.
+   */
+  private suspend fun PointerInputScope.detectGestures() {
+    coroutineScope {
+      launch { detectDrags() }
+      // Skipped entirely when there is no onClick, so callers like the FAB — whose content has its
+      // own clickable — do not get a down-consumer they have no use for.
+      if (onClick != null) launch { detectTaps() }
+    }
+  }
+
+  /**
+   * [detectTapGestures] with no `onLongPress` applies no long-press timeout: it fires on release
+   * regardless of hold duration. So a long-press that never moves would otherwise register as a tap,
+   * which is what the [DraggableOverlayState.isDragging] guard rules out.
+   */
+  private suspend fun PointerInputScope.detectTaps() {
+    detectTapGestures(onTap = { if (!state.isDragging) onClick?.invoke() })
+  }
+
+  private suspend fun PointerInputScope.detectDrags() {
     detectDragGesturesAfterLongPress(
       onDragStart = {
-        state.isDragging = true
-        onHapticFeedback()
-      },
-      onDragEnd = {
-        scope.launch {
-          state.snapToEdge(screenSize.width.toFloat(), contentSize.width.toFloat())
-          state.isDragging = false
+        state.onDragStarted()
+        if (hapticFeedbackEnabled) {
+          currentValueOf(LocalHapticFeedback).performHapticFeedback(HapticFeedbackType.LongPress)
         }
-      },
-      onDragCancel = {
-        state.isDragging = false
       },
       onDrag = { change, dragAmount ->
         change.consume()
-        scope.launch {
-          state.updateOffset(
-            dragDeltaX = dragAmount.x,
-            dragDeltaY = dragAmount.y,
-            contentSize = contentSize,
-            screenSize = screenSize
-          )
-        }
+        // Accumulate synchronously so no delta can be lost, then flush an absolute position. The
+        // flush is safe to cancel or drop: the next one catches up.
+        state.onDrag(dragAmount, change.uptimeMillis)
+        coroutineScope.launch { state.flushDrag() }
+      },
+      onDragEnd = {
+        // Ends with the gesture, not with the settle animation. Clearing it only after settle
+        // completes would keep the alpha/scale feedback applied for the whole animation, and would
+        // make DraggableOverlayPanel's `if (!state.isDragging)` tap guard swallow taps during it.
+        state.onDragStopped()
+        coroutineScope.launch { state.settle() }
+      },
+      onDragCancel = {
+        state.onDragStopped()
       }
     )
   }
+
+  /**
+   * Note this fires on every drag frame, not just on real size changes: moving the window via
+   * `WindowManager.updateViewLayout` calls through to `ViewRootImpl.setLayoutParams` →
+   * `requestLayout()`, which force-lays-out the ComposeView. Hence the size guard — without it,
+   * bounds would be re-clamped and the observeReads re-registered 60+ times a second.
+   */
+  override fun onRemeasured(size: IntSize) {
+    if (contentSize != size) {
+      contentSize = size
+      refreshBounds()
+    }
+  }
+
+  override fun onObservedReadsChanged() {
+    refreshBounds()
+  }
+
+  /**
+   * Re-reads the container size and hands both sizes to [state].
+   *
+   * [observeReads] only tracks a single pass, so this has to re-register the observation every time
+   * it runs — that is what keeps [onObservedReadsChanged] firing on subsequent container changes.
+   */
+  private fun refreshBounds() {
+    observeReads {
+      containerSize = currentValueOf(LocalWindowInfo).containerSize
+    }
+    state.updateBounds(contentSize, containerSize)
+  }
+
+  fun update(state: DraggableOverlayState, hapticFeedbackEnabled: Boolean, onClick: (() -> Unit)?) {
+    this.hapticFeedbackEnabled = hapticFeedbackEnabled
+
+    // Only the null-ness matters to the handler; the lambda itself is read fresh on every tap, so it
+    // can never go stale and a mere identity change needs no restart.
+    val tapDetectionChanged = (this.onClick == null) != (onClick == null)
+    this.onClick = onClick
+    if (tapDetectionChanged) {
+      pointerInputNode.resetPointerInputHandler()
+    }
+
+    if (this.state !== state) {
+      this.state = state
+      refreshBounds()
+    }
+  }
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayState.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayState.kt
@@ -107,10 +107,18 @@ internal class DraggableOverlayState(initialOffset: Offset, private val decayAni
     offset.snapTo(dragTarget)
 
     val velocity = velocityTracker.calculateVelocity()
-    // Gesture velocity is in screen coords (+x = rightward), but offset uses END gravity
-    // (x=0 is the right edge, increasing leftward) — so x must be negated. y needs no
-    // conversion: gravity is TOP and both increase downward.
-    val initialVelocity = Offset(-velocity.x, velocity.y)
+    // Horizontal only, and the y component is deliberately dropped rather than converted.
+    //
+    // Bounds on a 2-D Animatable are an animation *terminator*, not a per-axis clamp: runAnimation
+    // calls cancelAnimation() as soon as clampToBounds alters ANY component. Since the target below
+    // keeps y where the user left it, any y velocity can only push y out of bounds — which would
+    // abort the x snap mid-flight and strand the overlay mid-screen. Releasing while dragging
+    // against the top or bottom edge did exactly that. Zero y velocity keeps y in bounds, so the
+    // only reachable bound-hit is x arriving at an edge, which is the intended terminator.
+    //
+    // x is negated because gesture velocity is in screen coords (+x = rightward) while offset uses
+    // END gravity (x=0 is the right edge, increasing leftward).
+    val initialVelocity = Offset(-velocity.x, 0f)
     val decay = decayAnimSpec.calculateTargetValue(Offset.VectorConverter, offset.value, initialVelocity)
 
     val maxX = maxOffset.x
@@ -148,7 +156,7 @@ internal class DraggableOverlayState(initialOffset: Offset, private val decayAni
 @Composable
 internal fun rememberDraggableOverlayState(initialOffset: Offset = Offset.Zero): DraggableOverlayState {
   val decay = rememberSplineBasedDecay<Offset>()
-  return remember(decay) {
+  return remember {
     DraggableOverlayState(initialOffset, decay)
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayState.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DraggableOverlayState.kt
@@ -1,83 +1,154 @@
 package com.ms.square.debugoverlay.internal.ui
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.DecayAnimationSpec
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.calculateTargetValue
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.IntSize
 
 /**
  * State holder for draggable overlay components (FAB, Panel, etc.).
  *
- * Manages position animations, bounds clamping, and snap-to-edge behavior.
- * Uses gravity END/TOP coordinate system where x=0 is right edge, y=0 is top.
+ * Owns the whole motion model — position, bounds, drag accumulation, velocity and settle behavior —
+ * and is the only place the gravity END/TOP coordinate convention (x=0 is the right edge, y=0 is the
+ * top) is applied. Callers and modifiers work in plain screen-space deltas; the conversion happens
+ * here and nowhere else.
  *
- * @param initialOffsetX Initial X offset from right edge
- * @param initialOffsetY Initial Y offset from top
+ * @param initialOffset Initial offset from top-right edge
  */
 @Stable
-internal class DraggableOverlayState(initialOffsetX: Float, initialOffsetY: Float) {
-  val offsetX = Animatable(initialOffsetX)
-  val offsetY = Animatable(initialOffsetY)
+internal class DraggableOverlayState(initialOffset: Offset, private val decayAnimSpec: DecayAnimationSpec<Offset>) {
+
+  val offset = Animatable(initialOffset, Offset.VectorConverter)
 
   var isDragging by mutableStateOf(false)
-    internal set
+    private set
+
+  /** Largest allowed offset; set by [updateBounds]. */
+  private var maxOffset = Offset.Zero
 
   /**
-   * Snaps to the nearest horizontal edge with animation.
+   * Absolute drag target, accumulated synchronously by [onDrag]. Because flushes carry an absolute
+   * position rather than a delta, a canceled or superseded [flushDrag] costs at most one frame —
+   * the next flush catches up. A relative snapTo would lose that delta permanently, since
+   * [Animatable.snapTo] runs under a MutatorMutex where each call cancels the previous one.
+   */
+  private var dragTarget = Offset.Zero
+
+  /**
+   * Unclamped running total of the gesture's deltas, fed to [velocityTracker].
+   * Kept separate from [dragTarget] because it must stay unclamped: clamping would flatten
+   * velocity to zero whenever a drag is held against an edge, killing the fling.
+   */
+  private var dragDistance = Offset.Zero
+
+  private val velocityTracker = VelocityTracker()
+
+  /** Syncs the accumulators with the animated position, which [settle] may have moved. */
+  fun onDragStarted() {
+    dragTarget = offset.value
+    dragDistance = Offset.Zero
+    velocityTracker.resetTracking()
+    isDragging = true
+  }
+
+  /**
+   * Accumulates a screen-space drag delta. Deliberately NOT suspending: this must run synchronously
+   * inside the gesture callback, which is what makes losing a delta impossible.
    *
-   * @param screenWidth Total screen width
-   * @param contentWidth Width of the draggable content
+   * Clamps [dragTarget] against [maxOffset] — unclamped, dragging past an edge would build up a
+   * target you then have to drag all the way back before the overlay moved again. [dragDistance] is
+   * accumulated unclamped alongside it, for velocity.
    */
-  internal suspend fun snapToEdge(screenWidth: Float, contentWidth: Float) {
-    val maxX = (screenWidth - contentWidth).coerceAtLeast(0f)
-    val snapX = if (offsetX.value < maxX / 2) {
-      0f // Snap to END (right)
+  fun onDrag(dragDeltaOffset: Offset, timeMillis: Long) {
+    // END gravity: x=0 is the right edge, so a LEFT drag (negative delta) increases x.
+    // Gravity is TOP, so DOWN (positive delta) increases y.
+    dragTarget = Offset(
+      x = (dragTarget.x - dragDeltaOffset.x).coerceIn(0f, maxOffset.x),
+      y = (dragTarget.y + dragDeltaOffset.y).coerceIn(0f, maxOffset.y)
+    )
+    dragDistance += dragDeltaOffset
+    velocityTracker.addPosition(timeMillis, dragDistance)
+  }
+
+  /**
+   * Ends the gesture. Call before launching [settle] — clearing this first is what stops a late
+   * [flushDrag] from fighting the settle animation.
+   */
+  fun onDragStopped() {
+    isDragging = false
+  }
+
+  /** Applies the accumulated [dragTarget]. Safe to cancel or skip entirely. */
+  suspend fun flushDrag() {
+    // A flush queued during the final onDrag can be scheduled after settle has already started;
+    // without this it would snap back mid-animation. settle applies dragTarget itself, so skipping
+    // here loses nothing.
+    if (!isDragging) return
+    offset.snapTo(dragTarget)
+  }
+
+  /**
+   * Flings and snaps to the nearest horizontal edge, using the velocity accumulated during the
+   * gesture. Bounds come from the last [updateBounds] call.
+   */
+  suspend fun settle() {
+    // Apply the final accumulated position first: the last flushDrag may have been skipped by the
+    // !isDragging guard, and decay must be computed from where the finger actually left off.
+    offset.snapTo(dragTarget)
+
+    val velocity = velocityTracker.calculateVelocity()
+    // Gesture velocity is in screen coords (+x = rightward), but offset uses END gravity
+    // (x=0 is the right edge, increasing leftward) — so x must be negated. y needs no
+    // conversion: gravity is TOP and both increase downward.
+    val initialVelocity = Offset(-velocity.x, velocity.y)
+    val decay = decayAnimSpec.calculateTargetValue(Offset.VectorConverter, offset.value, initialVelocity)
+
+    val maxX = maxOffset.x
+    val toRightEdge = decay.x < maxX / 2f
+    // Decay lands on an edge only if it overshoots it; bounds clamp the remainder.
+    val decayReachesEdge = if (toRightEdge) decay.x <= 0f else decay.x >= maxX
+    if (decayReachesEdge) {
+      offset.animateDecay(initialVelocity = initialVelocity, animationSpec = decayAnimSpec)
     } else {
-      maxX // Snap to START (left)
-    }
-    offsetX.animateTo(targetValue = snapX, animationSpec = tween())
-  }
-
-  /**
-   * Updates offset based on drag gesture, with bounds clamping.
-   * Uses gravity END/TOP coordinate system (x=0 is right edge, y=0 is top).
-   */
-  internal suspend fun updateOffset(dragDeltaX: Float, dragDeltaY: Float, contentSize: IntSize, screenSize: IntSize) {
-    // In screen coords: LEFT drag is negative dragDeltaX, RIGHT drag is positive
-    // END gravity: x=0 is right edge, so LEFT (negative delta) should increase offsetX
-    // Formula: offsetX - dragDeltaX converts negative delta to positive offset increase
-    offsetX.snapTo((offsetX.value - dragDeltaX).coerceIn(0f, maxX(contentSize, screenSize)))
-    // DOWN is positive (gravity is TOP)
-    offsetY.snapTo((offsetY.value + dragDeltaY).coerceIn(0f, maxY(contentSize, screenSize)))
-  }
-
-  /**
-   * Clamps position when screen/content size changes (e.g., rotation).
-   */
-  internal suspend fun clampToBounds(contentSize: IntSize, screenSize: IntSize) {
-    if (contentSize.width > 0 && contentSize.height > 0) {
-      val clampedX = offsetX.value.coerceIn(0f, maxX(contentSize, screenSize))
-      val clampedY = offsetY.value.coerceIn(0f, maxY(contentSize, screenSize))
-
-      if (offsetX.value != clampedX) offsetX.snapTo(clampedX)
-      if (offsetY.value != clampedY) offsetY.snapTo(clampedY)
+      offset.animateTo(
+        targetValue = Offset(if (toRightEdge) 0f else maxX, offset.value.y),
+        initialVelocity = initialVelocity
+      )
     }
   }
 
-  private fun maxX(contentSize: IntSize, screenSize: IntSize): Float =
-    (screenSize.width - contentSize.width).coerceAtLeast(0).toFloat()
+  /**
+   * Recomputes the draggable region and re-clamps the current offset when screen/content size changes (e.g., rotation).
+   */
+  fun updateBounds(contentSize: IntSize, containerSize: IntSize) {
+    if (contentSize.width <= 0 || contentSize.height <= 0) return
+    // coerceAtLeast(0) is required: Animatable.updateBounds() throws if lower > upper, which happens
+    // whenever the content is larger than its container.
+    maxOffset = Offset(
+      x = (containerSize.width - contentSize.width).coerceAtLeast(0).toFloat(),
+      y = (containerSize.height - contentSize.height).coerceAtLeast(0).toFloat()
+    )
+    offset.updateBounds(Offset.Zero, maxOffset)
+  }
 
-  private fun maxY(contentSize: IntSize, screenSize: IntSize): Float =
-    (screenSize.height - contentSize.height).coerceAtLeast(0).toFloat()
+  override fun toString(): String = "DraggableOverlayState(offset=${offset.value}, isDragging=$isDragging, " +
+    "maxOffset=$maxOffset, dragTarget=$dragTarget, dragDistance=$dragDistance)"
 }
 
 @Composable
-internal fun rememberDraggableOverlayState(initialOffsetX: Float, initialOffsetY: Float): DraggableOverlayState =
-  remember {
-    DraggableOverlayState(initialOffsetX, initialOffsetY)
+internal fun rememberDraggableOverlayState(initialOffset: Offset = Offset.Zero): DraggableOverlayState {
+  val decay = rememberSplineBasedDecay<Offset>()
+  return remember(decay) {
+    DraggableOverlayState(initialOffset, decay)
   }
+}

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="debugoverlay_debug_panel">Debug Panel</string>
   <string name="debugoverlay_close">Close</string>
   <string name="debugoverlay_clear_logs_content_description">Clear collected logs</string>
+  <string name="debugoverlay_panel_content_description">Debug overlay metrics</string>
+  <string name="debugoverlay_panel_open_action_label">Open debug panel</string>
 
   <!-- Tab Titles -->
   <string name="debugoverlay_tab_log">Log</string>

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
   <string name="debugoverlay_debug_panel">Debug Panel</string>
   <string name="debugoverlay_close">Close</string>
   <string name="debugoverlay_clear_logs_content_description">Clear collected logs</string>
-  <string name="debugoverlay_panel_content_description">Debug overlay metrics</string>
   <string name="debugoverlay_panel_open_action_label">Open debug panel</string>
 
   <!-- Tab Titles -->


### PR DESCRIPTION
  Rewrites the drag modifier as a Modifier.Node and consolidates all motion logic in DraggableOverlayState.

  - Drops the screenSize, contentSize and scope params — the node derives each itself. Both call sites lose their size tracking and bounds LaunchedEffect.
  - No pointerInput keys, so the gesture detector no longer restarts whenever a size changes.
  - DragVisualFeedback → plain draggingAlpha / draggingScale params.
  - DraggableOverlayState owns position, bounds, velocity and settle, and is the only place the END/TOP gravity inversion lives.