### PR TITLE
refactor: drop redundant rememberUpdatedState and callback indirection

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftPickerScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftPickerScreen.kt
@@ -2,20 +2,17 @@ package com.ms.square.debugoverlay.internal.bugreport.ui
 
 import android.graphics.Bitmap
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.res.stringResource
 import com.ms.square.debugoverlay.DebugOverlay
 import com.ms.square.debugoverlay.core.R
@@ -23,56 +20,12 @@ import com.ms.square.debugoverlay.internal.Logger
 import com.ms.square.debugoverlay.internal.bugreport.BugReportGenerator
 import com.ms.square.debugoverlay.internal.bugreport.model.DraftInfo
 import com.ms.square.debugoverlay.internal.util.runCatchingNonCancellation
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 
 private const val THUMBNAIL_MAX_DIMENSION = 160
-
-/**
- * Holds localized strings used in the draft picker.
- */
-private data class DraftPickerStrings(
-  val undoLabel: String,
-  val deletedMessage: String,
-  val draftNotFoundMessage: String,
-  val captureErrorMessage: String,
-)
-
-@Composable
-private fun rememberDraftPickerStrings(): DraftPickerStrings = DraftPickerStrings(
-  undoLabel = stringResource(R.string.debugoverlay_undo),
-  deletedMessage = stringResource(R.string.debugoverlay_draft_deleted),
-  draftNotFoundMessage = stringResource(R.string.debugoverlay_draft_not_found),
-  captureErrorMessage = stringResource(R.string.debugoverlay_bug_report_error)
-)
-
-/**
- * Holds UI state for the draft picker screen.
- * References are stable (don't change), but the objects themselves contain mutable state.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Stable
-private class DraftPickerState(
-  val scope: CoroutineScope,
-  val snackbarHostState: SnackbarHostState,
-  val sheetState: SheetState,
-  val draftSelectionState: DraftSelectionState,
-)
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun rememberDraftPickerState(): DraftPickerState {
-  val scope = rememberCoroutineScope()
-  val snackbarHostState = remember { SnackbarHostState() }
-  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-  val draftSelectionState = rememberDraftSelectionState()
-  return remember(scope, snackbarHostState, sheetState, draftSelectionState) {
-    DraftPickerState(scope, snackbarHostState, sheetState, draftSelectionState)
-  }
-}
 
 /**
  * Screen for selecting a saved draft or creating a new bug report.
@@ -88,6 +41,7 @@ private fun rememberDraftPickerState(): DraftPickerState {
  * @param onDismiss Called when the sheet is dismissed
  * @param onError Called when an error occurs (e.g., capture failure)
  */
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DraftPickerScreen(
@@ -97,8 +51,10 @@ internal fun DraftPickerScreen(
   onDismiss: () -> Unit,
   onError: suspend (String) -> Unit,
 ) {
-  val state = rememberDraftPickerState()
-  val strings = rememberDraftPickerStrings()
+  val snackbarHostState = remember { SnackbarHostState() }
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+  val draftSelectionState = rememberDraftSelectionState()
+  val scope = rememberCoroutineScope()
 
   // Observe drafts from storage
   val drafts by bugReportGenerator.drafts.collectAsState(initial = emptyList())
@@ -109,24 +65,67 @@ internal fun DraftPickerScreen(
   // Load thumbnails for drafts
   LoadThumbnailsEffect(bugReportGenerator, drafts, thumbnails)
 
-  // Create callbacks
-  val callbacks = rememberDraftSelectionCallbacks(
-    bugReportGenerator = bugReportGenerator,
-    state = state,
-    onDraftSelected = onDraftSelected,
-    onNewCaptureCreated = onNewCaptureCreated,
-    onDismiss = onDismiss,
-    onError = onError,
-    strings = strings
-  )
+  val undoLabel = stringResource(R.string.debugoverlay_undo)
+  val deletedMessage = stringResource(R.string.debugoverlay_draft_deleted)
+  val draftNotFoundMessage = stringResource(R.string.debugoverlay_draft_not_found)
+  val captureErrorMessage = stringResource(R.string.debugoverlay_bug_report_error)
 
   DraftSelectionBottomSheet(
     drafts = drafts,
     thumbnails = thumbnails,
-    sheetState = state.sheetState,
-    snackbarHostState = state.snackbarHostState,
-    state = state.draftSelectionState,
-    callbacks = callbacks
+    sheetState = sheetState,
+    snackbarHostState = snackbarHostState,
+    state = draftSelectionState,
+    onCreateNew = {
+      scope.launch {
+        sheetState.hide()
+        bugReportGenerator.captureToFolder()
+          .onSuccess { folder -> onNewCaptureCreated(folder) }
+          .onFailure {
+            Logger.e("Failed to capture new bug report", it)
+            onError(captureErrorMessage)
+            onDismiss()
+          }
+      }
+    },
+    onDraftSelected = { draft ->
+      scope.launch {
+        if (draft.folder.exists()) {
+          sheetState.hide()
+          onDraftSelected(draft)
+        } else {
+          snackbarHostState.showSnackbar(draftNotFoundMessage)
+        }
+      }
+    },
+    onDraftDeleted = { draft ->
+      scope.launch {
+        val result = snackbarHostState.showSnackbar(
+          message = deletedMessage,
+          actionLabel = undoLabel,
+          duration = SnackbarDuration.Short
+        )
+        when (result) {
+          SnackbarResult.ActionPerformed -> draftSelectionState.undoDelete(draft)
+          SnackbarResult.Dismissed -> withContext(NonCancellable) {
+            bugReportGenerator.deleteCaptureFolder(draft.folder)
+            draftSelectionState.confirmDelete(draft)
+          }
+        }
+      }
+    },
+    onDismiss = {
+      scope.launch {
+        // Use NonCancellable to ensure deletions complete even if scope is cancelled
+        // (e.g., when Activity finishes during auto-dismiss)
+        withContext(NonCancellable) {
+          draftSelectionState.pendingDelete.values.toList().forEach { draft ->
+            bugReportGenerator.deleteCaptureFolder(draft.folder)
+          }
+        }
+        onDismiss()
+      }
+    }
   )
 }
 
@@ -163,79 +162,5 @@ private fun LoadThumbnailsEffect(
         thumbnails[draft.folderPath] = thumbnail
       }
     }
-  }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun rememberDraftSelectionCallbacks(
-  bugReportGenerator: BugReportGenerator,
-  state: DraftPickerState,
-  onDraftSelected: (DraftInfo) -> Unit,
-  onNewCaptureCreated: (File) -> Unit,
-  onDismiss: () -> Unit,
-  onError: suspend (String) -> Unit,
-  strings: DraftPickerStrings,
-): DraftSelectionCallbacks {
-  // Use rememberUpdatedState to capture latest values without recreating callbacks
-  val currentOnDraftSelected by rememberUpdatedState(onDraftSelected)
-  val currentOnNewCaptureCreated by rememberUpdatedState(onNewCaptureCreated)
-  val currentOnDismiss by rememberUpdatedState(onDismiss)
-  val currentOnError by rememberUpdatedState(onError)
-  val currentStrings by rememberUpdatedState(strings)
-
-  return remember(state) {
-    DraftSelectionCallbacks(
-      onCreateNew = {
-        state.scope.launch {
-          state.sheetState.hide()
-          bugReportGenerator.captureToFolder()
-            .onSuccess { folder -> currentOnNewCaptureCreated(folder) }
-            .onFailure {
-              Logger.e("Failed to capture new bug report", it)
-              currentOnError(currentStrings.captureErrorMessage)
-              currentOnDismiss()
-            }
-        }
-      },
-      onDraftSelected = { draft ->
-        state.scope.launch {
-          if (draft.folder.exists()) {
-            state.sheetState.hide()
-            currentOnDraftSelected(draft)
-          } else {
-            state.snackbarHostState.showSnackbar(currentStrings.draftNotFoundMessage)
-          }
-        }
-      },
-      onDraftDeleted = { draft ->
-        state.scope.launch {
-          val result = state.snackbarHostState.showSnackbar(
-            message = currentStrings.deletedMessage,
-            actionLabel = currentStrings.undoLabel,
-            duration = SnackbarDuration.Short
-          )
-          when (result) {
-            SnackbarResult.ActionPerformed -> state.draftSelectionState.undoDelete(draft)
-            SnackbarResult.Dismissed -> withContext(NonCancellable) {
-              bugReportGenerator.deleteCaptureFolder(draft.folder)
-              state.draftSelectionState.confirmDelete(draft)
-            }
-          }
-        }
-      },
-      onDismiss = {
-        state.scope.launch {
-          // Use NonCancellable to ensure deletions complete even if scope is cancelled
-          // (e.g., when Activity finishes during auto-dismiss)
-          withContext(NonCancellable) {
-            state.draftSelectionState.pendingDelete.values.toList().forEach { draft ->
-              bugReportGenerator.deleteCaptureFolder(draft.folder)
-            }
-          }
-          currentOnDismiss()
-        }
-      }
-    )
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftSelectionBottomSheet.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/ui/DraftSelectionBottomSheet.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -85,17 +84,6 @@ internal class DraftSelectionState {
 internal fun rememberDraftSelectionState(): DraftSelectionState = remember { DraftSelectionState() }
 
 /**
- * Callbacks for [DraftSelectionBottomSheet] actions.
- */
-@Immutable
-internal data class DraftSelectionCallbacks(
-  val onCreateNew: () -> Unit,
-  val onDraftSelected: (DraftInfo) -> Unit,
-  val onDraftDeleted: (DraftInfo) -> Unit,
-  val onDismiss: () -> Unit,
-)
-
-/**
  * Bottom sheet for selecting a draft to resume or creating a new report.
  *
  * Shows:
@@ -105,7 +93,7 @@ internal data class DraftSelectionCallbacks(
  *
  * Implements delay-delete pattern:
  * - Delete hides the item immediately
- * - Caller shows undo snackbar via [DraftSelectionCallbacks.onDraftDeleted] callback
+ * - Caller shows undo snackbar via the [onDraftDeleted] callback
  * - Caller calls [DraftSelectionState.confirmDelete] after timeout
  * - Caller calls [DraftSelectionState.undoDelete] if user taps undo
  *
@@ -114,8 +102,12 @@ internal data class DraftSelectionCallbacks(
  * @param sheetState Sheet state for controlling visibility
  * @param snackbarHostState Snackbar host state for undo messages
  * @param state State holder for delay-delete pattern
- * @param callbacks Callbacks for user actions
+ * @param onCreateNew Called when the "Create New Report" button is tapped
+ * @param onDraftSelected Called when a draft is chosen
+ * @param onDraftDeleted Called when a draft's delete button is tapped
+ * @param onDismiss Called when the sheet is dismissed
  */
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DraftSelectionBottomSheet(
@@ -124,12 +116,15 @@ internal fun DraftSelectionBottomSheet(
   sheetState: SheetState,
   snackbarHostState: SnackbarHostState,
   state: DraftSelectionState,
-  callbacks: DraftSelectionCallbacks,
+  onCreateNew: () -> Unit,
+  onDraftSelected: (DraftInfo) -> Unit,
+  onDraftDeleted: (DraftInfo) -> Unit,
+  onDismiss: () -> Unit,
 ) {
   val visibleDrafts = state.filterVisible(drafts)
 
   ModalBottomSheet(
-    onDismissRequest = callbacks.onDismiss,
+    onDismissRequest = onDismiss,
     sheetState = sheetState,
     containerColor = MaterialTheme.colorScheme.surfaceContainerLow
   ) {
@@ -138,7 +133,9 @@ internal fun DraftSelectionBottomSheet(
         visibleDrafts = visibleDrafts,
         thumbnails = thumbnails,
         state = state,
-        callbacks = callbacks
+        onCreateNew = onCreateNew,
+        onDraftSelected = onDraftSelected,
+        onDraftDeleted = onDraftDeleted
       )
 
       SnackbarHost(
@@ -156,14 +153,16 @@ private fun DraftSelectionContent(
   visibleDrafts: List<DraftInfo>,
   thumbnails: Map<String, Bitmap?>,
   state: DraftSelectionState,
-  callbacks: DraftSelectionCallbacks,
+  onCreateNew: () -> Unit,
+  onDraftSelected: (DraftInfo) -> Unit,
+  onDraftDeleted: (DraftInfo) -> Unit,
 ) {
   Column(
     modifier = Modifier
       .fillMaxWidth()
       .navigationBarsPadding()
   ) {
-    CreateNewButton(onClick = callbacks.onCreateNew)
+    CreateNewButton(onClick = onCreateNew)
     Spacer(modifier = Modifier.height(8.dp))
     HorizontalDivider()
     Spacer(modifier = Modifier.height(8.dp))
@@ -172,8 +171,8 @@ private fun DraftSelectionContent(
       drafts = visibleDrafts,
       thumbnails = thumbnails,
       state = state,
-      onDraftSelected = callbacks.onDraftSelected,
-      onDraftDeleted = callbacks.onDraftDeleted
+      onDraftSelected = onDraftSelected,
+      onDraftDeleted = onDraftDeleted
     )
     Spacer(modifier = Modifier.height(16.dp))
   }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/DebugOverlayPanel.kt
@@ -62,7 +62,6 @@ internal fun DraggableOverlayPanel(
   onClick: () -> Unit,
 ) {
   val currentOnPositionChanged by rememberUpdatedState(onPositionChanged)
-  val currentOnClick by rememberUpdatedState(onClick)
 
   val state = rememberDraggableOverlayState(
     initialOffset = Offset(initialOffsetX, initialOffsetY)
@@ -88,7 +87,7 @@ internal fun DraggableOverlayPanel(
         role = Role.Button
       ) {
         if (!state.isDragging) {
-          currentOnClick()
+          onClick()
         }
       }
       // Merge so TalkBack stops once on the panel rather than on every metric row. Deliberately no


### PR DESCRIPTION
Removes rememberUpdatedState where it wasn't buying anything, along with the wrapper types that existed to work around it.

  - DebugOverlayPanel — Modifier.clickable is rebuilt every recomposition and ClickableElement.update() pushes the fresh lambda into the node, so wrapping onClick was redundant. The one feeding LaunchedEffect(Unit) is kept — that
  coroutine captures once and never restarts, so it genuinely needs it.
  - DraftPickerScreen — deletes DraftSelectionCallbacks, DraftPickerState and DraftPickerStrings. The callbacks were cached in remember(state), which is what made rememberUpdatedState necessary in the first place; building them
  inline at the call site removes both. Nothing is cached, so nothing can go stale.
  - DraftSelectionBottomSheet — takes the four callbacks directly instead of a wrapper object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified draft selection and bug-report screen behavior without changing user-facing functionality.
  * Improved handling of draft creation, selection, deletion, undo, dismissal, notifications, and capture errors.
  * Streamlined interactions in the draggable overlay panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->