### PR TITLE
feat: add copy-all button to export full network request details

### DIFF
--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/bugreport/HtmlReportBuilder.kt
@@ -12,6 +12,7 @@ import com.ms.square.debugoverlay.internal.data.model.DeviceInfo
 import com.ms.square.debugoverlay.internal.data.model.JankStatsUiState
 import com.ms.square.debugoverlay.internal.util.HTTP_SUCCESS_END
 import com.ms.square.debugoverlay.internal.util.HTTP_SUCCESS_START
+import com.ms.square.debugoverlay.internal.util.contentType
 import com.ms.square.debugoverlay.internal.util.escapeHtml
 import com.ms.square.debugoverlay.internal.util.formatBytes
 import com.ms.square.debugoverlay.internal.util.formatBytesFromKb
@@ -658,9 +659,6 @@ internal object HtmlReportBuilder {
       appendBodySection("Response Body", body, request.responseHeaders.contentType())
     }
   }
-
-  private fun Map<String, String>.contentType(): String? =
-    entries.firstOrNull { it.key.equals("content-type", ignoreCase = true) }?.value
 
   /**
    * Renders a request/response body, pretty-printing it first if it is JSON.

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.CopyAll
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Info
@@ -56,6 +57,7 @@ import com.ms.square.debugoverlay.internal.util.formatBytes
 import com.ms.square.debugoverlay.internal.util.formatTimestamp
 import com.ms.square.debugoverlay.internal.util.httpStatusColor
 import com.ms.square.debugoverlay.internal.util.httpStatusMessage
+import com.ms.square.debugoverlay.internal.util.toClipboardText
 import com.ms.square.debugoverlay.model.NetworkRequest
 
 /**
@@ -102,6 +104,14 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
             Icon(
               imageVector = Icons.Default.ContentCopy,
               contentDescription = stringResource(R.string.debugoverlay_copy)
+            )
+          }
+          IconButton(onClick = {
+            scope.copyToClipboard(clipboard, request.toClipboardText())
+          }) {
+            Icon(
+              imageVector = Icons.Default.CopyAll,
+              contentDescription = stringResource(R.string.debugoverlay_copy_all)
             )
           }
         },

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -61,7 +60,6 @@ import com.ms.square.debugoverlay.internal.util.httpStatusColor
 import com.ms.square.debugoverlay.internal.util.httpStatusMessage
 import com.ms.square.debugoverlay.internal.util.toClipboardText
 import com.ms.square.debugoverlay.model.NetworkRequest
-import kotlinx.coroutines.CoroutineScope
 
 /**
  * Network request detail screen with TopAppBar and comprehensive information.
@@ -69,8 +67,6 @@ import kotlinx.coroutines.CoroutineScope
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> Unit, modifier: Modifier = Modifier) {
-  val clipboard = LocalClipboard.current
-  val scope = rememberCoroutineScope()
   val urlParts = remember(request.url) { UrlParts.from(request.url) }
 
   Scaffold(
@@ -101,7 +97,7 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
           BackButton(onClick = onBack)
         },
         actions = {
-          NetworkRequestDetailActions(request = request, clipboard = clipboard, scope = scope)
+          NetworkRequestDetailActions(request)
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -121,7 +117,9 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
  * TopAppBar actions: copy the URL alone, or the full request/response transaction.
  */
 @Composable
-private fun NetworkRequestDetailActions(request: NetworkRequest, clipboard: Clipboard, scope: CoroutineScope) {
+private fun NetworkRequestDetailActions(request: NetworkRequest) {
+  val clipboard = LocalClipboard.current
+  val scope = rememberCoroutineScope()
   IconButton(onClick = {
     scope.copyToClipboard(clipboard, request.url)
   }) {
@@ -131,7 +129,7 @@ private fun NetworkRequestDetailActions(request: NetworkRequest, clipboard: Clip
     )
   }
   IconButton(onClick = {
-    scope.copyToClipboard(clipboard) { request.toClipboardText() }
+    scope.copyToClipboard(clipboard, request.toClipboardText())
   }) {
     Icon(
       imageVector = Icons.Default.CopyAll,

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/ui/NetworkRequestDetailScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -52,6 +53,7 @@ import androidx.compose.ui.unit.dp
 import com.ms.square.debugoverlay.core.R
 import com.ms.square.debugoverlay.internal.data.TextType
 import com.ms.square.debugoverlay.internal.data.UrlParts
+import com.ms.square.debugoverlay.internal.util.contentType
 import com.ms.square.debugoverlay.internal.util.copyToClipboard
 import com.ms.square.debugoverlay.internal.util.formatBytes
 import com.ms.square.debugoverlay.internal.util.formatTimestamp
@@ -59,6 +61,7 @@ import com.ms.square.debugoverlay.internal.util.httpStatusColor
 import com.ms.square.debugoverlay.internal.util.httpStatusMessage
 import com.ms.square.debugoverlay.internal.util.toClipboardText
 import com.ms.square.debugoverlay.model.NetworkRequest
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Network request detail screen with TopAppBar and comprehensive information.
@@ -98,22 +101,7 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
           BackButton(onClick = onBack)
         },
         actions = {
-          IconButton(onClick = {
-            scope.copyToClipboard(clipboard, request.url)
-          }) {
-            Icon(
-              imageVector = Icons.Default.ContentCopy,
-              contentDescription = stringResource(R.string.debugoverlay_copy)
-            )
-          }
-          IconButton(onClick = {
-            scope.copyToClipboard(clipboard, request.toClipboardText())
-          }) {
-            Icon(
-              imageVector = Icons.Default.CopyAll,
-              contentDescription = stringResource(R.string.debugoverlay_copy_all)
-            )
-          }
+          NetworkRequestDetailActions(request = request, clipboard = clipboard, scope = scope)
         },
         colors = TopAppBarDefaults.topAppBarColors(
           containerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -125,6 +113,29 @@ internal fun NetworkRequestDetailScreen(request: NetworkRequest, onBack: () -> U
       request = request,
       urlParts = urlParts,
       modifier = Modifier.padding(paddingValues)
+    )
+  }
+}
+
+/**
+ * TopAppBar actions: copy the URL alone, or the full request/response transaction.
+ */
+@Composable
+private fun NetworkRequestDetailActions(request: NetworkRequest, clipboard: Clipboard, scope: CoroutineScope) {
+  IconButton(onClick = {
+    scope.copyToClipboard(clipboard, request.url)
+  }) {
+    Icon(
+      imageVector = Icons.Default.ContentCopy,
+      contentDescription = stringResource(R.string.debugoverlay_copy_url)
+    )
+  }
+  IconButton(onClick = {
+    scope.copyToClipboard(clipboard) { request.toClipboardText() }
+  }) {
+    Icon(
+      imageVector = Icons.Default.CopyAll,
+      contentDescription = stringResource(R.string.debugoverlay_copy_all)
     )
   }
 }
@@ -224,7 +235,7 @@ private fun OverviewTab(request: NetworkRequest, urlParts: UrlParts, modifier: M
         DetailSection(title = "Response Summary") {
           InfoCard {
             var itemCount = 0
-            request.responseHeaders["content-type"]?.let {
+            request.responseHeaders.contentType()?.let {
               InfoRow("Content-Type", it)
               itemCount++
             }
@@ -354,7 +365,7 @@ private fun BodyTab(request: NetworkRequest, modifier: Modifier = Modifier) {
         if (request.requestBody != null) {
           BodyPreview(
             body = request.requestBody,
-            contentType = request.requestHeaders["content-type"]
+            contentType = request.requestHeaders.contentType()
           )
         } else {
           EmptyState(text = stringResource(R.string.debugoverlay_network_no_request_body))
@@ -375,7 +386,7 @@ private fun BodyTab(request: NetworkRequest, modifier: Modifier = Modifier) {
         if (request.responseBody != null) {
           BodyPreview(
             body = request.responseBody,
-            contentType = request.responseHeaders["content-type"]
+            contentType = request.responseHeaders.contentType()
           )
         } else {
           EmptyState(text = stringResource(R.string.debugoverlay_network_no_response_body))

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Clipboards.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Clipboards.kt
@@ -4,26 +4,11 @@ import android.content.ClipData
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 internal fun CoroutineScope.copyToClipboard(clipboard: Clipboard, text: String, label: String = "") {
   launch {
     val clipEntry = ClipEntry(ClipData.newPlainText(label, text))
-    clipboard.setClipEntry(clipEntry)
-  }
-}
-
-/**
- * Builds the clipboard text off the main thread before copying. Use this overload when [text]
- * is expensive enough to risk jank (e.g. formatting an entire network transaction), instead of
- * computing it inline at the call site.
- */
-internal fun CoroutineScope.copyToClipboard(clipboard: Clipboard, label: String = "", text: suspend () -> String) {
-  launch {
-    val resolved = withContext(Dispatchers.Default) { text() }
-    val clipEntry = ClipEntry(ClipData.newPlainText(label, resolved))
     clipboard.setClipEntry(clipEntry)
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Clipboards.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Clipboards.kt
@@ -4,11 +4,26 @@ import android.content.ClipData
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal fun CoroutineScope.copyToClipboard(clipboard: Clipboard, text: String, label: String = "") {
   launch {
     val clipEntry = ClipEntry(ClipData.newPlainText(label, text))
+    clipboard.setClipEntry(clipEntry)
+  }
+}
+
+/**
+ * Builds the clipboard text off the main thread before copying. Use this overload when [text]
+ * is expensive enough to risk jank (e.g. formatting an entire network transaction), instead of
+ * computing it inline at the call site.
+ */
+internal fun CoroutineScope.copyToClipboard(clipboard: Clipboard, label: String = "", text: suspend () -> String) {
+  launch {
+    val resolved = withContext(Dispatchers.Default) { text() }
+    val clipEntry = ClipEntry(ClipData.newPlainText(label, resolved))
     clipboard.setClipEntry(clipEntry)
   }
 }

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Headers.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/Headers.kt
@@ -1,0 +1,9 @@
+package com.ms.square.debugoverlay.internal.util
+
+/**
+ * Case-insensitive content-type lookup. Headers are captured verbatim off the wire, so casing
+ * varies by protocol (HTTP/2 lowercases header names, HTTP/1.1 typically capitalizes them);
+ * an exact-key map lookup silently misses the latter.
+ */
+internal fun Map<String, String>.contentType(): String? =
+  entries.firstOrNull { it.key.equals("content-type", ignoreCase = true) }?.value

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
@@ -10,8 +10,11 @@ import com.ms.square.debugoverlay.model.NetworkRequest
  * omitting any section that has nothing to show. Response headers/body are included whenever
  * captured, even alongside an error section - the OkHttp extension populates [NetworkRequest]'s
  * `error` for any HTTP status of 400 or above while still capturing the response.
+ *
+ * @param maxClipBoardLength per-body character cap before truncation, defaulting to
+ *   [MAX_CLIPBOARD_BODY_LENGTH].
  */
-internal fun NetworkRequest.toClipboardText(): String = buildString {
+internal fun NetworkRequest.toClipboardText(maxClipBoardLength: Int = MAX_CLIPBOARD_BODY_LENGTH): String = buildString {
   appendLine("$method $url")
   appendLine("Status: ${statusCode?.let { "$it ${it.httpStatusMessage}" } ?: "Error"}")
   appendLine("Duration: $durationMs ms")
@@ -20,11 +23,11 @@ internal fun NetworkRequest.toClipboardText(): String = buildString {
   append("Response Size: ${formatBytes(responseSize)}")
 
   appendHeadersSection("Request Headers", requestHeaders)
-  appendBodySection("Request Body", requestBody, requestHeaders.contentType())
+  appendBodySection("Request Body", requestBody, requestHeaders.contentType(), maxClipBoardLength)
 
   error?.let { appendErrorSection(it) }
   appendHeadersSection("Response Headers", responseHeaders)
-  appendBodySection("Response Body", responseBody, responseHeaders.contentType())
+  appendBodySection("Response Body", responseBody, responseHeaders.contentType(), maxClipBoardLength)
 }
 
 private fun StringBuilder.appendHeadersSection(title: String, headers: Map<String, String>) {
@@ -33,11 +36,16 @@ private fun StringBuilder.appendHeadersSection(title: String, headers: Map<Strin
   append(headers.entries.joinToString("\n") { (name, value) -> "$name: $value" })
 }
 
-private fun StringBuilder.appendBodySection(title: String, body: String?, contentType: String?) {
+private fun StringBuilder.appendBodySection(
+  title: String,
+  body: String?,
+  contentType: String?,
+  maxClipBoardLength: Int,
+) {
   if (body.isNullOrEmpty()) return
   append("\n\n--- $title ---\n")
   val formatted = if (TextType.from(body, contentType) == TextType.JSON) formatJsonIfPossible(body) else body
-  append(formatted.truncateForClipboard())
+  append(formatted.truncateForClipboard(maxClipBoardLength))
 }
 
 private fun StringBuilder.appendErrorSection(error: NetworkError) {
@@ -52,16 +60,16 @@ private fun StringBuilder.appendErrorSection(error: NetworkError) {
 }
 
 /**
- * Caps a single body at [MAX_CLIPBOARD_BODY_LENGTH]. The OkHttp extension allows bodies up to
+ * Caps a single body at [maxClipBoardLength]. The OkHttp extension allows bodies up to
  * 2MB each by default; concatenating an uncapped request and response body into one ClipData
  * risks TransactionTooLargeException when it crosses the clipboard's Binder call.
  */
-private fun String.truncateForClipboard(): String = if (length <= MAX_CLIPBOARD_BODY_LENGTH) {
+private fun String.truncateForClipboard(maxClipBoardLength: Int): String = if (length <= maxClipBoardLength) {
   this
 } else {
-  val shownSize = formatBytes(MAX_CLIPBOARD_BODY_LENGTH.toLong())
+  val shownSize = formatBytes(maxClipBoardLength.toLong())
   val totalSize = formatBytes(length.toLong())
-  "${take(MAX_CLIPBOARD_BODY_LENGTH)}...\n\n[truncated: showing $shownSize of $totalSize]"
+  "${take(maxClipBoardLength)}...\n\n[truncated: showing $shownSize of $totalSize]"
 }
 
 private const val MAX_CLIPBOARD_BODY_LENGTH = 64 * 1024

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
@@ -7,25 +7,24 @@ import com.ms.square.debugoverlay.model.NetworkRequest
 /**
  * Format the full request/response transaction as plain text for clipboard copy.
  * Mirrors the Overview/Headers/Body sections shown on the network request detail screen,
- * omitting any section that has nothing to show.
+ * omitting any section that has nothing to show. Response headers/body are included whenever
+ * captured, even alongside an error section - the OkHttp extension populates [NetworkRequest]'s
+ * `error` for any HTTP status of 400 or above while still capturing the response.
  */
 internal fun NetworkRequest.toClipboardText(): String = buildString {
   appendLine("$method $url")
   appendLine("Status: ${statusCode?.let { "$it ${it.httpStatusMessage}" } ?: "Error"}")
   appendLine("Duration: $durationMs ms")
-  appendLine("Timestamp: ${formatTimestamp(timestampMs)}")
+  appendLine("Timestamp: ${formatClipboardTimestamp(timestampMs)}")
   appendLine("Request Size: ${formatBytes(requestSize)}")
   append("Response Size: ${formatBytes(responseSize)}")
 
   appendHeadersSection("Request Headers", requestHeaders)
-  appendBodySection("Request Body", requestBody, requestHeaders["content-type"])
+  appendBodySection("Request Body", requestBody, requestHeaders.contentType())
 
-  if (error != null) {
-    appendErrorSection(error)
-  } else {
-    appendHeadersSection("Response Headers", responseHeaders)
-    appendBodySection("Response Body", responseBody, responseHeaders["content-type"])
-  }
+  error?.let { appendErrorSection(it) }
+  appendHeadersSection("Response Headers", responseHeaders)
+  appendBodySection("Response Body", responseBody, responseHeaders.contentType())
 }
 
 private fun StringBuilder.appendHeadersSection(title: String, headers: Map<String, String>) {
@@ -38,7 +37,7 @@ private fun StringBuilder.appendBodySection(title: String, body: String?, conten
   if (body.isNullOrEmpty()) return
   append("\n\n--- $title ---\n")
   val formatted = if (TextType.from(body, contentType) == TextType.JSON) formatJsonIfPossible(body) else body
-  append(formatted)
+  append(formatted.truncateForClipboard())
 }
 
 private fun StringBuilder.appendErrorSection(error: NetworkError) {
@@ -51,3 +50,18 @@ private fun StringBuilder.appendErrorSection(error: NetworkError) {
     append(it)
   }
 }
+
+/**
+ * Caps a single body at [MAX_CLIPBOARD_BODY_LENGTH]. The OkHttp extension allows bodies up to
+ * 2MB each by default; concatenating an uncapped request and response body into one ClipData
+ * risks TransactionTooLargeException when it crosses the clipboard's Binder call.
+ */
+private fun String.truncateForClipboard(): String = if (length <= MAX_CLIPBOARD_BODY_LENGTH) {
+  this
+} else {
+  val shownSize = formatBytes(MAX_CLIPBOARD_BODY_LENGTH.toLong())
+  val totalSize = formatBytes(length.toLong())
+  "${take(MAX_CLIPBOARD_BODY_LENGTH)}...\n\n[truncated: showing $shownSize of $totalSize]"
+}
+
+private const val MAX_CLIPBOARD_BODY_LENGTH = 64 * 1024

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormatting.kt
@@ -1,0 +1,53 @@
+package com.ms.square.debugoverlay.internal.util
+
+import com.ms.square.debugoverlay.internal.data.TextType
+import com.ms.square.debugoverlay.model.NetworkError
+import com.ms.square.debugoverlay.model.NetworkRequest
+
+/**
+ * Format the full request/response transaction as plain text for clipboard copy.
+ * Mirrors the Overview/Headers/Body sections shown on the network request detail screen,
+ * omitting any section that has nothing to show.
+ */
+internal fun NetworkRequest.toClipboardText(): String = buildString {
+  appendLine("$method $url")
+  appendLine("Status: ${statusCode?.let { "$it ${it.httpStatusMessage}" } ?: "Error"}")
+  appendLine("Duration: $durationMs ms")
+  appendLine("Timestamp: ${formatTimestamp(timestampMs)}")
+  appendLine("Request Size: ${formatBytes(requestSize)}")
+  append("Response Size: ${formatBytes(responseSize)}")
+
+  appendHeadersSection("Request Headers", requestHeaders)
+  appendBodySection("Request Body", requestBody, requestHeaders["content-type"])
+
+  if (error != null) {
+    appendErrorSection(error)
+  } else {
+    appendHeadersSection("Response Headers", responseHeaders)
+    appendBodySection("Response Body", responseBody, responseHeaders["content-type"])
+  }
+}
+
+private fun StringBuilder.appendHeadersSection(title: String, headers: Map<String, String>) {
+  if (headers.isEmpty()) return
+  append("\n\n--- $title ---\n")
+  append(headers.entries.joinToString("\n") { (name, value) -> "$name: $value" })
+}
+
+private fun StringBuilder.appendBodySection(title: String, body: String?, contentType: String?) {
+  if (body.isNullOrEmpty()) return
+  append("\n\n--- $title ---\n")
+  val formatted = if (TextType.from(body, contentType) == TextType.JSON) formatJsonIfPossible(body) else body
+  append(formatted)
+}
+
+private fun StringBuilder.appendErrorSection(error: NetworkError) {
+  append("\n\n--- Error ---\n")
+  append(error.title)
+  append('\n')
+  append(error.message)
+  error.stackTrace?.let {
+    append('\n')
+    append(it)
+  }
+}

--- a/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/TimeFormatters.kt
+++ b/debugoverlay-core/src/main/kotlin/com/ms/square/debugoverlay/internal/util/TimeFormatters.kt
@@ -22,7 +22,7 @@ internal fun formatTimestamp(timestamp: Long): String =
 /**
  * Format timestamp for clipboard copy (e.g., "12-11 14:35:22.786").
  */
-private fun formatClipboardTimestamp(timestamp: Long): String =
+internal fun formatClipboardTimestamp(timestamp: Long): String =
   SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US).format(Date(timestamp))
 
 /**

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
   <!-- Common Actions -->
   <string name="debugoverlay_back">Back</string>
   <string name="debugoverlay_copy">Copy</string>
+  <string name="debugoverlay_copy_all">Copy all</string>
   <string name="debugoverlay_refresh">Refresh</string>
   <string name="debugoverlay_clear_search">Clear search</string>
   <string name="debugoverlay_view_details">View details</string>

--- a/debugoverlay-core/src/main/res/values/strings.xml
+++ b/debugoverlay-core/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
   <!-- Common Actions -->
   <string name="debugoverlay_back">Back</string>
   <string name="debugoverlay_copy">Copy</string>
+  <string name="debugoverlay_copy_url">Copy URL</string>
   <string name="debugoverlay_copy_all">Copy all</string>
   <string name="debugoverlay_refresh">Refresh</string>
   <string name="debugoverlay_clear_search">Clear search</string>

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
@@ -1,0 +1,139 @@
+package com.ms.square.debugoverlay.internal.util
+
+import com.google.common.truth.Truth.assertThat
+import com.ms.square.debugoverlay.model.NetworkError
+import com.ms.square.debugoverlay.model.NetworkRequest
+import org.junit.Test
+
+class NetworkRequestFormattingTest {
+
+  @Test
+  fun `toClipboardText includes all sections for a full request and response`() {
+    val request = NetworkRequest(
+      protocol = "h2",
+      method = "POST",
+      url = "https://api.example.com/v1/users",
+      statusCode = 200,
+      durationMs = 245,
+      responseSize = 128,
+      requestSize = 42,
+      timestampMs = 1_700_000_000_000,
+      requestHeaders = mapOf("content-type" to "application/json"),
+      responseHeaders = mapOf("content-type" to "application/json"),
+      requestBody = """{"name":"test"}""",
+      responseBody = """{"result":"ok"}"""
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).isEqualTo(
+      """
+      POST https://api.example.com/v1/users
+      Status: 200 OK
+      Duration: 245 ms
+      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Request Size: 42 B
+      Response Size: 128 B
+
+      --- Request Headers ---
+      content-type: application/json
+
+      --- Request Body ---
+      {
+          "name": "test"
+      }
+
+      --- Response Headers ---
+      content-type: application/json
+
+      --- Response Body ---
+      {
+          "result": "ok"
+      }
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `toClipboardText omits headers and body sections when absent`() {
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/ping",
+      statusCode = 204,
+      durationMs = 12,
+      responseSize = 0,
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).isEqualTo(
+      """
+      GET https://api.example.com/v1/ping
+      Status: 204 No Content
+      Duration: 12 ms
+      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Request Size: 0 B
+      Response Size: 0 B
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `toClipboardText leaves non-JSON body unformatted`() {
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/text",
+      statusCode = 200,
+      durationMs = 5,
+      responseSize = 11,
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000,
+      responseBody = "plain text"
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).contains("--- Response Body ---\nplain text")
+  }
+
+  @Test
+  fun `toClipboardText shows error section instead of response headers and body`() {
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/fail",
+      statusCode = null,
+      durationMs = 1000,
+      responseSize = null,
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000,
+      error = NetworkError(
+        title = "Connection failed",
+        message = "Unable to resolve host",
+        stackTrace = "java.net.UnknownHostException: api.example.com"
+      )
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).isEqualTo(
+      """
+      GET https://api.example.com/v1/fail
+      Status: Error
+      Duration: 1000 ms
+      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Request Size: 0 B
+      Response Size: —
+
+      --- Error ---
+      Connection failed
+      Unable to resolve host
+      java.net.UnknownHostException: api.example.com
+      """.trimIndent()
+    )
+  }
+}

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
@@ -31,7 +31,7 @@ class NetworkRequestFormattingTest {
       POST https://api.example.com/v1/users
       Status: 200 OK
       Duration: 245 ms
-      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Timestamp: ${formatClipboardTimestamp(request.timestampMs)}
       Request Size: 42 B
       Response Size: 128 B
 
@@ -74,7 +74,7 @@ class NetworkRequestFormattingTest {
       GET https://api.example.com/v1/ping
       Status: 204 No Content
       Duration: 12 ms
-      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Timestamp: ${formatClipboardTimestamp(request.timestampMs)}
       Request Size: 0 B
       Response Size: 0 B
       """.trimIndent()
@@ -101,7 +101,55 @@ class NetworkRequestFormattingTest {
   }
 
   @Test
-  fun `toClipboardText shows error section instead of response headers and body`() {
+  fun `toClipboardText detects JSON via a capitalized Content-Type header`() {
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/data",
+      statusCode = 200,
+      durationMs = 10,
+      responseSize = 20,
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000,
+      responseHeaders = mapOf("Content-Type" to "application/json"),
+      responseBody = """{"a":1}"""
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).contains(
+      """
+      --- Response Body ---
+      {
+          "a": 1
+      }
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `toClipboardText truncates a body larger than the clipboard cap`() {
+    val hugeBody = "a".repeat(HUGE_BODY_LENGTH)
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/large",
+      statusCode = 200,
+      durationMs = 10,
+      responseSize = HUGE_BODY_LENGTH.toLong(),
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000,
+      responseBody = hugeBody
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).contains("[truncated: showing 64.0 KB of")
+    assertThat(result).doesNotContain(hugeBody)
+  }
+
+  @Test
+  fun `toClipboardText shows error section for a transport failure with no response data`() {
     val request = NetworkRequest(
       protocol = "http/1.1",
       method = "GET",
@@ -125,7 +173,7 @@ class NetworkRequestFormattingTest {
       GET https://api.example.com/v1/fail
       Status: Error
       Duration: 1000 ms
-      Timestamp: ${formatTimestamp(request.timestampMs)}
+      Timestamp: ${formatClipboardTimestamp(request.timestampMs)}
       Request Size: 0 B
       Response Size: —
 
@@ -136,4 +184,48 @@ class NetworkRequestFormattingTest {
       """.trimIndent()
     )
   }
+
+  @Test
+  fun `toClipboardText includes both error and response sections for an HTTP error status`() {
+    val request = NetworkRequest(
+      protocol = "http/1.1",
+      method = "GET",
+      url = "https://api.example.com/v1/resource",
+      statusCode = 404,
+      durationMs = 80,
+      responseSize = 42,
+      requestSize = 0,
+      timestampMs = 1_700_000_000_000,
+      responseHeaders = mapOf("content-type" to "application/json"),
+      responseBody = """{"error":"not found"}""",
+      error = NetworkError(title = "HTTP 404", message = "Not Found")
+    )
+
+    val result = request.toClipboardText()
+
+    assertThat(result).isEqualTo(
+      """
+      GET https://api.example.com/v1/resource
+      Status: 404 Not Found
+      Duration: 80 ms
+      Timestamp: ${formatClipboardTimestamp(request.timestampMs)}
+      Request Size: 0 B
+      Response Size: 42 B
+
+      --- Error ---
+      HTTP 404
+      Not Found
+
+      --- Response Headers ---
+      content-type: application/json
+
+      --- Response Body ---
+      {
+          "error": "not found"
+      }
+      """.trimIndent()
+    )
+  }
 }
+
+private const val HUGE_BODY_LENGTH = 70_000

--- a/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
+++ b/debugoverlay-core/src/test/kotlin/com/ms/square/debugoverlay/internal/util/NetworkRequestFormattingTest.kt
@@ -129,22 +129,23 @@ class NetworkRequestFormattingTest {
 
   @Test
   fun `toClipboardText truncates a body larger than the clipboard cap`() {
-    val hugeBody = "a".repeat(HUGE_BODY_LENGTH)
+    val bodyLengthAboveThreshold = 10
+    val hugeBody = "a".repeat(bodyLengthAboveThreshold)
     val request = NetworkRequest(
       protocol = "http/1.1",
       method = "GET",
       url = "https://api.example.com/v1/large",
       statusCode = 200,
       durationMs = 10,
-      responseSize = HUGE_BODY_LENGTH.toLong(),
+      responseSize = bodyLengthAboveThreshold.toLong(),
       requestSize = 0,
       timestampMs = 1_700_000_000_000,
       responseBody = hugeBody
     )
 
-    val result = request.toClipboardText()
+    val result = request.toClipboardText(bodyLengthAboveThreshold / 2)
 
-    assertThat(result).contains("[truncated: showing 64.0 KB of")
+    assertThat(result).contains("[truncated: showing ${bodyLengthAboveThreshold / 2} B of")
     assertThat(result).doesNotContain(hugeBody)
   }
 
@@ -227,5 +228,3 @@ class NetworkRequestFormattingTest {
     )
   }
 }
-
-private const val HUGE_BODY_LENGTH = 70_000


### PR DESCRIPTION
## Summary
Add a "Copy All" button to the network request detail screen that exports the complete request/response transaction as formatted plain text, suitable for sharing or debugging.

## Changes
- **New utility function** `NetworkRequest.toClipboardText()` that formats the full network transaction (overview, headers, body, or error) as plain text
  - Mirrors the Overview/Headers/Body sections shown on the detail screen
  - Omits empty sections (headers/body when absent)
  - Automatically formats JSON bodies with indentation
  - Leaves non-JSON bodies unformatted
  - Shows error details instead of response headers/body when a request fails

- **UI enhancement** to `NetworkRequestDetailScreen`
  - Added "Copy All" button (CopyAll icon) next to existing copy buttons in the top app bar
  - Reuses existing clipboard copy infrastructure

- **String resource** added for the new button's content description (`debugoverlay_copy_all`)

- **Comprehensive test coverage** with 4 test cases covering:
  - Full request/response with all sections
  - Minimal request with no headers/body
  - Non-JSON body handling
  - Error state formatting

## Implementation Details
The formatting function builds a structured text output with:
- Request line (method + URL)
- Status, duration, timestamp, and sizes
- Optional request/response headers and bodies
- Optional error section with title, message, and stack trace
- JSON pretty-printing when applicable

https://claude.ai/code/session_01A5yvCH5EjpW2JdJZ1ggiTY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to copy a network request URL or all request and response details.
  * Copied details include metadata, headers, bodies, errors, and formatted JSON when applicable.
  * Large request and response bodies are safely truncated with size information.

* **Bug Fixes**
  * Improved content-type detection regardless of header capitalization.
  * Preserved response details when requests contain errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->