### PR TITLE
docs: update README for v2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Version 2.6.3 *(2026-08-06)*
+
+### New Features
+
+* **Copy the full transaction from a network request** – The network request detail screen gains a "Copy all" action in the top app bar, alongside the existing per-section copy buttons. It exports method, URL, status, timing, sizes, both header sets and both bodies as a single plain-text block, with JSON bodies pretty-printed and each body capped at 64 KB so a large transaction cannot overflow a single `ClipData`. Content-Type lookups are now case-insensitive, so HTTP/2's lowercased headers are detected as well. Resolves item 2 of [#256](https://github.com/Manabu-GT/DebugOverlay-Android/issues/256).
+
+### Build
+
+* Update Gradle to 9.6.1.
+
 ## Version 2.6.2 *(2026-07-21)*
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* **Copy the full transaction from a network request** – The network request detail screen gains a "Copy all" action in the top app bar, alongside the existing per-section copy buttons. It exports method, URL, status, timing, sizes, both header sets and both bodies as a single plain-text block, with JSON bodies pretty-printed and each body capped at 64 KB so a large transaction cannot overflow a single `ClipData`. Content-Type lookups are now case-insensitive, so HTTP/2's lowercased headers are detected as well. Resolves item 2 of [#256](https://github.com/Manabu-GT/DebugOverlay-Android/issues/256).
+* **Copy the full transaction from a network request** – The network request detail screen gains a "Copy all" action in the top app bar, alongside the existing per-section copy buttons. It exports method, URL, status, timing, sizes, both header sets and both bodies as a single plain-text block, with JSON bodies pretty-printed and each body section capped at 64 KB to reduce the risk of overflowing a single `ClipData`. Content-Type lookups are now case-insensitive, so HTTP/2's lowercased headers are detected as well. Resolves item 2 of [#256](https://github.com/Manabu-GT/DebugOverlay-Android/issues/256).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ DebugOverlay gives you a lightweight, always-available look into your app's runt
 
 ```kotlin
 // app/build.gradle.kts
-debugImplementation("com.ms-square:debugoverlay:2.6.2")
+debugImplementation("com.ms-square:debugoverlay:2.6.3")
 
 // That's it! Overlay appears automatically on app launch.
 // Tap to open debug panel. Long-press to drag.
@@ -74,7 +74,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-debugoverlay = "2.6.2"
+debugoverlay = "2.6.3"
 
 [libraries]
 debugoverlay = { module = "com.ms-square:debugoverlay", version.ref = "debugoverlay" }
@@ -100,7 +100,7 @@ dependencies {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay:2.6.3")
 }
 ```
 
@@ -155,8 +155,8 @@ For a zero-config shake trigger, add the shake extension:
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.2")
-  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay:2.6.3")
+  debugImplementation("com.ms-square:debugoverlay-extension-trigger-shake:2.6.3")
 }
 ```
 
@@ -208,8 +208,8 @@ The value also bounds the `logcat -T N` / `-t N` calls, so it caps how many line
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.2")
-  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay:2.6.3")
+  debugImplementation("com.ms-square:debugoverlay-extension-okhttp:2.6.3")
 }
 ```
 
@@ -240,8 +240,8 @@ val client = OkHttpClient.Builder()
 
 ```kotlin
 dependencies {
-  debugImplementation("com.ms-square:debugoverlay:2.6.2")
-  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.2")
+  debugImplementation("com.ms-square:debugoverlay:2.6.3")
+  debugImplementation("com.ms-square:debugoverlay-extension-timber:2.6.3")
 }
 ```
 
@@ -365,7 +365,7 @@ android {
 }
 
 dependencies {
-  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.2")
+  "releaseWithOverlayImplementation"("com.ms-square:debugoverlay:2.6.3")
 }
 ```
 


### PR DESCRIPTION
Release prep for v2.6.3.

- Bump dependency coordinate examples in README from 2.6.2 to 2.6.3 (10 references).
- Add CHANGELOG entry for v2.6.3:
  - **New Features** — the network request detail screen's "Copy all" export (#268), which resolves item 2 of #256.
  - **Build** — Gradle 9.6.1 (#267).

Internal-only changes in this range (#265 `Modifier.Node` drag rewrite, #266 `rememberUpdatedState` cleanup) are intentionally left out of the changelog — no consumer-visible impact.

Docs only; no build or test run required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Version 2.6.3 release notes describing full transaction copying in network request details.
  * Documented formatted, size-limited request and response bodies, including case-insensitive content-type handling.
  * Documented the Gradle 9.6.1 upgrade.
  * Updated Quick Start and integration examples to use DebugOverlay version 2.6.3 across supported configurations and extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->